### PR TITLE
feat(thread): implement SThread::Create for windows

### DIFF
--- a/storm/CMakeLists.txt
+++ b/storm/CMakeLists.txt
@@ -27,6 +27,14 @@ if(WHOA_SYSTEM_MAC)
     list(APPEND STORM_SOURCES ${STORM_MAC_SOURCES})
 endif()
 
+if(WHOA_SYSTEM_LINUX)
+    file(GLOB STORM_LINUX_SOURCES
+        "linux/*.cpp"
+        "thread/linux/*.cpp"
+    )
+    list(APPEND STORM_SOURCES ${STORM_LINUX_SOURCES})
+endif()
+
 add_library(storm STATIC
     ${STORM_SOURCES}
 )

--- a/storm/Thread.hpp
+++ b/storm/Thread.hpp
@@ -9,7 +9,7 @@
 #include "storm/thread/SThread.hpp"
 #include <cstdint>
 
-int32_t SCreateThread(uint32_t (*threadProc)(void*), void* threadParam, void* a3, SThread* syncObject, const char* threadName);
+void* SCreateThread(uint32_t (*threadProc)(void*), void* threadParam, void* a3, SThread* syncObject, const char* threadName);
 
 uintptr_t SGetCurrentThreadId();
 

--- a/storm/thread/SThread.cpp
+++ b/storm/thread/SThread.cpp
@@ -3,8 +3,10 @@
 
 int32_t SThread::Create(uint32_t (*threadProc)(void*), void* param, SThread& thread, char* threadName, uint32_t a5) {
 #if defined(WHOA_SYSTEM_WIN)
-    // TODO implement
-    return 0;
+    uint32_t v8;
+    auto handle = SCreateThread(threadProc, param, &v8, nullptr, nullptr);
+    thread.m_opaqueData = handle;
+    return handle != nullptr;
 #endif
 
 #if defined(WHOA_SYSTEM_MAC) || defined(WHOA_SYSTEM_LINUX)
@@ -13,6 +15,7 @@ int32_t SThread::Create(uint32_t (*threadProc)(void*), void* param, SThread& thr
     pthread_cond_init(&thread.m_cond, nullptr);
 
     uint32_t v8;
-    return SCreateThread(threadProc, param, &v8, &thread, nullptr) != 0;
+    auto handle = SCreateThread(threadProc, param, &v8, &thread, nullptr);
+    return handle != nullptr;
 #endif
 }

--- a/storm/thread/linux/Thread.cpp
+++ b/storm/thread/linux/Thread.cpp
@@ -1,0 +1,6 @@
+#include "storm/Thread.hpp"
+
+void* SCreateThread(uint32_t (*threadProc)(void*), void* threadParam, void* a3, SThread* syncObject, const char* threadName) {
+    // TODO
+    return reinterpret_cast<void*>(1);
+}

--- a/storm/thread/mac/Thread.mm
+++ b/storm/thread/mac/Thread.mm
@@ -5,7 +5,7 @@
 #include "storm/thread/mac/SThreadRunner.h"
 #include <new>
 
-int32_t SCreateThread(uint32_t (*threadProc)(void*), void* threadParam, void* a3, SThread* syncObject, const char* threadName) {
+void* SCreateThread(uint32_t (*threadProc)(void*), void* threadParam, void* a3, SThread* syncObject, const char* threadName) {
     if (!threadName) {
         threadName = "";
     }
@@ -71,5 +71,5 @@ int32_t SCreateThread(uint32_t (*threadProc)(void*), void* threadParam, void* a3
     // TODO
     // S_Thread::s_threadCrit.Leave();
 
-    return threadId;
+    return reinterpret_cast<void*>(threadId);
 }

--- a/storm/thread/win/Thread.cpp
+++ b/storm/thread/win/Thread.cpp
@@ -1,0 +1,6 @@
+#include "storm/Thread.hpp"
+
+void* SCreateThread(uint32_t (*threadProc)(void*), void* threadParam, void* a3, SThread* syncObject, const char* threadName) {
+    // TODO
+    return reinterpret_cast<void*>(1);
+}

--- a/test/Thread.cpp
+++ b/test/Thread.cpp
@@ -1,6 +1,10 @@
 #include "storm/Thread.hpp"
 #include "test/Test.hpp"
 
+uint32_t threadProc(void* param) {
+    return 0;
+};
+
 TEST_CASE("SGetCurrentThreadId", "[thread]") {
     SECTION("returns thread id") {
         uintptr_t threadId = SGetCurrentThreadId();
@@ -22,5 +26,13 @@ TEST_CASE("SCritSect::Leave", "[thread]") {
         critSect.Enter();
         critSect.Leave();
         SUCCEED();
+    }
+}
+
+TEST_CASE("SThread::Create", "[thread]") {
+    SECTION("creates new thread") {
+        SThread thread;
+        char* threadName = const_cast<char*>("TestThread");
+        REQUIRE(SThread::Create(threadProc, nullptr, thread, threadName, 0) != 0);
     }
 }


### PR DESCRIPTION
This also corrects the return type for `SCreateThread`: the Windows implementation expects to store the new thread's `HANDLE` in `SThread`'s `SSyncObject`.

Note that the Mac and Linux implementations ignore the returned value apart from checking if it's non-zero.