### PR TITLE
feat(error): improve error macros

### DIFF
--- a/storm/Error.hpp
+++ b/storm/Error.hpp
@@ -12,17 +12,7 @@
 #endif
 
 #if defined(NDEBUG)
-#define STORM_ASSERT(x)                            \
-    if (!(x)) {                                    \
-        SErrSetLastError(ERROR_INVALID_PARAMETER); \
-        return 0;                                  \
-    }                                              \
-    (void)0
-#define STORM_ASSERT_VOID(x)                       \
-    if (!(x)) {                                    \
-        SErrSetLastError(ERROR_INVALID_PARAMETER); \
-        return;                                    \
-    }                                              \
+#define STORM_ASSERT(x)                          \
     (void)0
 #else
 #define STORM_ASSERT(x)                          \
@@ -31,13 +21,14 @@
         SErrDisplayAppFatal(#x);                 \
     }                                            \
     (void)0
-#define STORM_ASSERT_VOID(x)                     \
+#endif
+
+#define STORM_VALIDATE(x, y, ...)                \
     if (!(x)) {                                  \
-        SErrPrepareAppFatal(__FILE__, __LINE__); \
-        SErrDisplayAppFatal(#x);                 \
+        SErrSetLastError(y);                     \
+        return __VA_ARGS__;                      \
     }                                            \
     (void)0
-#endif
 
 [[noreturn]] void SErrDisplayAppFatal(const char* format, ...);
 

--- a/storm/String.cpp
+++ b/storm/String.cpp
@@ -208,6 +208,7 @@ void SStrInitialize() {
 
 const char* SStrChr(const char* string, char search) {
     STORM_ASSERT(string);
+    STORM_VALIDATE(string, ERROR_INVALID_PARAMETER, nullptr);
 
     if (!*string) {
         return nullptr;
@@ -226,6 +227,7 @@ const char* SStrChr(const char* string, char search) {
 
 const char* SStrChrR(const char* string, char search) {
     STORM_ASSERT(string);
+    STORM_VALIDATE(string, ERROR_INVALID_PARAMETER, nullptr);
 
     const char* result;
 
@@ -255,6 +257,7 @@ int32_t SStrCmpI(const char* string1, const char* string2, size_t maxchars) {
 size_t SStrCopy(char* dest, const char* source, size_t destsize) {
     STORM_ASSERT(dest);
     STORM_ASSERT(source);
+    STORM_VALIDATE(dest && source, ERROR_INVALID_PARAMETER, 0);
 
     char* destbuf = dest;
 
@@ -423,10 +426,14 @@ const char* SStrStr(const char* string, const char* search) {
 }
 
 void SStrTokenize(const char** string, char* buffer, size_t bufferchars, const char* whitespace, int32_t* quoted) {
-    STORM_ASSERT_VOID(string);
-    STORM_ASSERT_VOID(*string);
-    STORM_ASSERT_VOID(buffer || !bufferchars);
-    STORM_ASSERT_VOID(whitespace);
+    STORM_ASSERT(string);
+    STORM_VALIDATE(string, ERROR_INVALID_PARAMETER);
+    STORM_ASSERT(*string);
+    STORM_VALIDATE(*string, ERROR_INVALID_PARAMETER);
+    STORM_ASSERT(buffer || !bufferchars);
+    STORM_VALIDATE(buffer || !bufferchars, ERROR_INVALID_PARAMETER);
+    STORM_ASSERT(whitespace);
+    STORM_VALIDATE(whitespace, ERROR_INVALID_PARAMETER);
 
     int32_t inquotes = 0;
     int32_t usedquotes = 0;


### PR DESCRIPTION
This PR modifies the behavior of the `STORM_ASSERT` macro, removes the now-unnecessary `STORM_ASSERT_VOID` macro, and introduces a new `STORM_VALIDATE` macro based on additional observations of builds with and without assertions enabled.

It's very likely the `STORM_ASSERT` custom assertion macro does nothing in release builds.

Based on disassembly, it appears that `SErrSetLastError` is not always present when both `SErrPrepareAppFatal` and `SErrDisplayAppFatal` are, making it highly unlikely to be part of a custom assertion macro.

That said, `SErrSetLastError` does frequently appear after assertions on argument values at function starts, typically coupled with the `ERROR_INVALID_PARAMETER` error code. This pattern suggests the existence of a secondary macro for argument validation at runtime in release builds (ie. builds with assertions disabled).

The new `STORM_VALIDATE` macro always short-circuits function execution, returning at the point where validation failed. It supports an optional return value argument, allowing for short-circuits in all functions, regardless of whether they return values.