### PR TITLE
chore(build): add windows.h compile definitions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,15 @@ set(CMAKE_CXX_STANDARD 11)
 
 include(lib/system/cmake/system.cmake)
 
+# OS defines
+if(WHOA_SYSTEM_WIN)
+    # Avoid win32 header hell
+    add_compile_definitions(
+        NOMINMAX
+        WIN32_LEAN_AND_MEAN
+    )
+endif()
+
 add_subdirectory(lib)
 add_subdirectory(storm)
 add_subdirectory(test)


### PR DESCRIPTION
This PR kicks on defines for `NOMINMAX` and `WIN32_LEAN_AND_MEAN` globally, keeping headaches introduced by `#include <windows.h>` to a minimum.