### PR TITLE
feat(error): SErrDisplayError shim on Windows

### DIFF
--- a/storm/Error.cpp
+++ b/storm/Error.cpp
@@ -2,6 +2,7 @@
 #include <cstdarg>
 #include <cstdio>
 #include <cstdlib>
+#include <string>
 
 #if defined(WHOA_SYSTEM_WIN)
 #include <Windows.h>
@@ -22,35 +23,68 @@ static uint32_t s_lasterror = ERROR_SUCCESS;
 int32_t SErrDisplayError(uint32_t errorcode, const char* filename, int32_t linenumber, const char* description, int32_t recoverable, uint32_t exitcode, uint32_t a7) {
     // TODO
 
-    printf("\n=========================================================\n");
+#if defined(WHOA_SYSTEM_WIN)
+    #define S_ERR_MAX 1024
+
+    char buffer[S_ERR_MAX];
+    memset(buffer, 0, S_ERR_MAX);
+    int32_t offset = 0;
+
+    #define S_ERR_DISPLAY(...) \
+        if (offset < S_ERR_MAX) { \
+            offset += std::snprintf(&buffer[offset], S_ERR_MAX-offset, __VA_ARGS__); \
+        }
+#elif
+    #define S_ERR_DISPLAY printf
+
+    S_ERR_DISPLAY("\n=========================================================\n");
+#endif
 
     if (linenumber == -5) {
-        printf("Exception Raised!\n\n");
+        S_ERR_DISPLAY("Exception Raised!\n\n");
 
-        printf(" App:         %s\n", "GenericBlizzardApp");
+        S_ERR_DISPLAY(" App:         %s\n", "GenericBlizzardApp");
 
         if (errorcode != 0x85100000) {
-            printf(" Error Code:  0x%08X\n", errorcode);
+            S_ERR_DISPLAY(" Error Code:  0x%08X\n", errorcode);
         }
 
         // TODO output time
 
-        printf(" Error:       %s\n\n", description);
+        S_ERR_DISPLAY(" Error:       %s\n\n", description);
     } else {
-        printf("Assertion Failed!\n\n");
+        S_ERR_DISPLAY("Assertion Failed!\n\n");
 
-        printf(" App:         %s\n", "GenericBlizzardApp");
-        printf(" File:        %s\n", filename);
-        printf(" Line:        %d\n", linenumber);
+        S_ERR_DISPLAY(" App:         %s\n", "GenericBlizzardApp");
+        S_ERR_DISPLAY(" File:        %s\n", filename);
+        S_ERR_DISPLAY(" Line:        %d\n", linenumber);
 
         if (errorcode != 0x85100000) {
-            printf(" Error Code:  0x%08X\n", errorcode);
+            S_ERR_DISPLAY(" Error Code:  0x%08X\n", errorcode);
         }
 
         // TODO output time
 
-        printf(" Assertion:   %s\n", description);
+        S_ERR_DISPLAY(" Assertion:   %s\n", description);
     }
+
+#if defined(WHOA_SYSTEM_WIN)
+    // Display message in Visual Studio
+    OutputDebugStringA(buffer);
+
+    S_ERR_DISPLAY("\n Ctrl-C to copy error to clipboard\n");
+
+    const char* caption = "Fatal Error";
+    if (recoverable) {
+        caption = "Error";
+    }
+
+    MessageBoxA(nullptr, buffer, caption, MB_ICONERROR);
+
+    #undef S_ERR_MAX
+#endif
+
+#undef S_ERR_DISPLAY
 
     if (recoverable) {
         return 1;

--- a/storm/Error.cpp
+++ b/storm/Error.cpp
@@ -34,7 +34,7 @@ int32_t SErrDisplayError(uint32_t errorcode, const char* filename, int32_t linen
         if (offset < S_ERR_MAX) { \
             offset += std::snprintf(&buffer[offset], S_ERR_MAX-offset, __VA_ARGS__); \
         }
-#elif
+#else
     #define S_ERR_DISPLAY printf
 
     S_ERR_DISPLAY("\n=========================================================\n");


### PR DESCRIPTION
In SErrDisplayError, use a macro to display error strings. On Windows, function opens a MessageBox to display the error messages written by this macro.