### PR TITLE
feat(big): add 14 SBig functions, fix couple of issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,11 @@
 .DS_Store
 .idea
 .vscode
+CMakeSettings.json
 
 /build
 /dist
+/out
+/.vs
+
+

--- a/storm/Big.cpp
+++ b/storm/Big.cpp
@@ -7,6 +7,10 @@ void SBigAdd(BigData* a, BigData* b, BigData* c) {
     Add(a->Primary(), b->Primary(), c->Primary());
 }
 
+void SBigAnd(BigData* a, BigData* b, BigData* c) {
+    And(a->Primary(), b->Primary(), c->Primary());
+}
+
 void SBigBitLen(BigData* num, uint32_t* len) {
     auto& buffer = num->Primary();
     buffer.Trim();

--- a/storm/Big.cpp
+++ b/storm/Big.cpp
@@ -73,6 +73,10 @@ int32_t SBigIsEven(BigData* a) {
     return IsEven(a->Primary());
 }
 
+int32_t SBigIsOdd(BigData* a) {
+    return IsOdd(a->Primary());
+}
+
 void SBigMod(BigData* a, BigData* b, BigData* c) {
     uint32_t allocCount = 0;
     auto& scratch = a->Stack().Alloc(&allocCount);

--- a/storm/Big.cpp
+++ b/storm/Big.cpp
@@ -46,7 +46,7 @@ void SBigDel(BigData* num) {
 
 void SBigDiv(BigData* a, BigData* b, BigData* c) {
     uint32_t allocCount = 0;
-    BigBuffer &buf = a->Stack().Alloc(&allocCount);
+    BigBuffer& buf = a->Stack().Alloc(&allocCount);
 
     Div(a->Primary(), buf, b->Primary(), c->Primary(), a->Stack());
 

--- a/storm/Big.cpp
+++ b/storm/Big.cpp
@@ -48,6 +48,10 @@ void SBigFromBinary(BigData* num, const void* data, uint32_t bytes) {
     FromBinary(num->Primary(), data, bytes);
 }
 
+void SBigFromStr(BigData* num, const char *str) {
+    FromStr(num->Primary(), str);
+}
+
 void SBigFromUnsigned(BigData* num, uint32_t val) {
     FromUnsigned(num->Primary(), val);
 }

--- a/storm/Big.cpp
+++ b/storm/Big.cpp
@@ -69,6 +69,10 @@ void SBigInc(BigData* a, BigData* b) {
     Add(a->Primary(), b->Primary(), 1);
 }
 
+int32_t SBigIsEven(BigData* a) {
+    return IsEven(a->Primary());
+}
+
 void SBigMod(BigData* a, BigData* b, BigData* c) {
     uint32_t allocCount = 0;
     auto& scratch = a->Stack().Alloc(&allocCount);

--- a/storm/Big.cpp
+++ b/storm/Big.cpp
@@ -32,6 +32,10 @@ int32_t SBigCompare(BigData* a, BigData* b) {
     return Compare(a->Primary(), b->Primary());
 }
 
+void SBigCopy(BigData* a, BigData* b) {
+    a->m_primary = b->m_primary;
+}
+
 void SBigDel(BigData* num) {
     delete num;
 }

--- a/storm/Big.cpp
+++ b/storm/Big.cpp
@@ -56,6 +56,10 @@ void SBigFromUnsigned(BigData* num, uint32_t val) {
     FromUnsigned(num->Primary(), val);
 }
 
+void SBigInc(BigData* a, BigData* b) {
+    Add(a->Primary(), b->Primary(), 1);
+}
+
 void SBigMod(BigData* a, BigData* b, BigData* c) {
     uint32_t allocCount = 0;
     auto& scratch = a->Stack().Alloc(&allocCount);

--- a/storm/Big.cpp
+++ b/storm/Big.cpp
@@ -81,6 +81,10 @@ int32_t SBigIsOne(BigData* a) {
     return IsOne(a->Primary());
 }
 
+int32_t SBigIsZero(BigData* a) {
+    return IsZero(a->Primary());
+}
+
 void SBigMod(BigData* a, BigData* b, BigData* c) {
     uint32_t allocCount = 0;
     auto& scratch = a->Stack().Alloc(&allocCount);

--- a/storm/Big.cpp
+++ b/storm/Big.cpp
@@ -77,6 +77,10 @@ int32_t SBigIsOdd(BigData* a) {
     return IsOdd(a->Primary());
 }
 
+int32_t SBigIsOne(BigData* a) {
+    return IsOne(a->Primary());
+}
+
 void SBigMod(BigData* a, BigData* b, BigData* c) {
     uint32_t allocCount = 0;
     auto& scratch = a->Stack().Alloc(&allocCount);

--- a/storm/Big.cpp
+++ b/storm/Big.cpp
@@ -142,3 +142,7 @@ void SBigToBinaryBuffer(BigData* num, uint8_t* data, uint32_t maxBytes, uint32_t
         *bytes = n;
     }
 }
+
+void SBigXor(BigData* a, BigData* b, BigData* c) {
+    Xor(a->Primary(), b->Primary(), c->Primary());
+}

--- a/storm/Big.cpp
+++ b/storm/Big.cpp
@@ -36,6 +36,10 @@ void SBigCopy(BigData* a, BigData* b) {
     a->m_primary = b->m_primary;
 }
 
+void SBigDec(BigData* a, BigData* b) {
+    Sub(a->m_primary, b->m_primary, 1);
+}
+
 void SBigDel(BigData* num) {
     delete num;
 }

--- a/storm/Big.cpp
+++ b/storm/Big.cpp
@@ -143,6 +143,10 @@ void SBigToBinaryBuffer(BigData* num, uint8_t* data, uint32_t maxBytes, uint32_t
     }
 }
 
+void SBigToUnsigned(BigData* num, uint32_t* val) {
+    ToUnsigned(val, num->Primary());
+}
+
 void SBigXor(BigData* a, BigData* b, BigData* c) {
     Xor(a->Primary(), b->Primary(), c->Primary());
 }

--- a/storm/Big.cpp
+++ b/storm/Big.cpp
@@ -107,6 +107,10 @@ void SBigNot(BigData* a, BigData* b) {
     Not(a->Primary(), b->Primary());
 }
 
+void SBigOr(BigData* a, BigData* b, BigData* c) {
+    Or(a->Primary(), b->Primary(), c->Primary());
+}
+
 void SBigPowMod(BigData* a, BigData* b, BigData* c, BigData* d) {
     PowMod(a->Primary(), b->Primary(), c->Primary(), d->Primary(), a->Stack());
 }

--- a/storm/Big.cpp
+++ b/storm/Big.cpp
@@ -44,6 +44,15 @@ void SBigDel(BigData* num) {
     delete num;
 }
 
+void SBigDiv(BigData* a, BigData* b, BigData* c) {
+    uint32_t allocCount = 0;
+    BigBuffer &buf = a->Stack().Alloc(&allocCount);
+
+    Div(a->Primary(), buf, b->Primary(), c->Primary(), a->Stack());
+
+    a->Stack().Free(allocCount);
+}
+
 void SBigFromBinary(BigData* num, const void* data, uint32_t bytes) {
     FromBinary(num->Primary(), data, bytes);
 }

--- a/storm/Big.cpp
+++ b/storm/Big.cpp
@@ -103,6 +103,10 @@ void SBigNew(BigData** num) {
     *num = new (m) BigData();
 }
 
+void SBigNot(BigData* a, BigData* b) {
+    Not(a->Primary(), b->Primary());
+}
+
 void SBigPowMod(BigData* a, BigData* b, BigData* c, BigData* d) {
     PowMod(a->Primary(), b->Primary(), c->Primary(), d->Primary(), a->Stack());
 }

--- a/storm/Big.hpp
+++ b/storm/Big.hpp
@@ -44,6 +44,8 @@ void SBigNew(BigData** num);
 
 void SBigNot(BigData* a, BigData* b);
 
+void SBigOr(BigData* a, BigData* b, BigData* c);
+
 void SBigPowMod(BigData* a, BigData* b, BigData* c, BigData* d);
 
 void SBigShl(BigData* a, BigData* b, uint32_t shift);

--- a/storm/Big.hpp
+++ b/storm/Big.hpp
@@ -60,4 +60,6 @@ void SBigToBinaryBuffer(BigData* num, uint8_t* data, uint32_t maxBytes, uint32_t
 
 void SBigXor(BigData* a, BigData* b, BigData* c);
 
+void SBigToUnsigned(BigData* num, uint32_t* val);
+
 #endif

--- a/storm/Big.hpp
+++ b/storm/Big.hpp
@@ -24,6 +24,8 @@ void SBigFromStr(BigData* num, const char* str);
 
 void SBigFromUnsigned(BigData* num, uint32_t val);
 
+void SBigInc(BigData* a, BigData* b);
+
 void SBigMod(BigData* a, BigData* b, BigData* c);
 
 void SBigMul(BigData* a, BigData* b, BigData* c);

--- a/storm/Big.hpp
+++ b/storm/Big.hpp
@@ -28,6 +28,8 @@ void SBigFromUnsigned(BigData* num, uint32_t val);
 
 void SBigInc(BigData* a, BigData* b);
 
+int32_t SBigIsEven(BigData* a);
+
 void SBigMod(BigData* a, BigData* b, BigData* c);
 
 void SBigMul(BigData* a, BigData* b, BigData* c);

--- a/storm/Big.hpp
+++ b/storm/Big.hpp
@@ -42,6 +42,8 @@ void SBigMul(BigData* a, BigData* b, BigData* c);
 
 void SBigNew(BigData** num);
 
+void SBigNot(BigData* a, BigData* b);
+
 void SBigPowMod(BigData* a, BigData* b, BigData* c, BigData* d);
 
 void SBigShl(BigData* a, BigData* b, uint32_t shift);

--- a/storm/Big.hpp
+++ b/storm/Big.hpp
@@ -30,6 +30,8 @@ void SBigInc(BigData* a, BigData* b);
 
 int32_t SBigIsEven(BigData* a);
 
+int32_t SBigIsOdd(BigData* a);
+
 void SBigMod(BigData* a, BigData* b, BigData* c);
 
 void SBigMul(BigData* a, BigData* b, BigData* c);

--- a/storm/Big.hpp
+++ b/storm/Big.hpp
@@ -34,6 +34,8 @@ int32_t SBigIsOdd(BigData* a);
 
 int32_t SBigIsOne(BigData* a);
 
+int32_t SBigIsZero(BigData* a);
+
 void SBigMod(BigData* a, BigData* b, BigData* c);
 
 void SBigMul(BigData* a, BigData* b, BigData* c);

--- a/storm/Big.hpp
+++ b/storm/Big.hpp
@@ -14,6 +14,8 @@ int32_t SBigCompare(BigData* a, BigData* b);
 
 void SBigCopy(BigData* a, BigData* b);
 
+void SBigDec(BigData* a, BigData* b);
+
 void SBigDel(BigData* num);
 
 void SBigFromBinary(BigData* num, const void* data, uint32_t bytes);

--- a/storm/Big.hpp
+++ b/storm/Big.hpp
@@ -32,6 +32,8 @@ int32_t SBigIsEven(BigData* a);
 
 int32_t SBigIsOdd(BigData* a);
 
+int32_t SBigIsOne(BigData* a);
+
 void SBigMod(BigData* a, BigData* b, BigData* c);
 
 void SBigMul(BigData* a, BigData* b, BigData* c);

--- a/storm/Big.hpp
+++ b/storm/Big.hpp
@@ -6,6 +6,8 @@
 
 void SBigAdd(BigData* a, BigData* b, BigData* c);
 
+void SBigAnd(BigData* a, BigData* b, BigData* c);
+
 void SBigBitLen(BigData* num, uint32_t* len);
 
 int32_t SBigCompare(BigData* a, BigData* b);

--- a/storm/Big.hpp
+++ b/storm/Big.hpp
@@ -58,4 +58,6 @@ void SBigSub(BigData* a, BigData* b, BigData* c);
 
 void SBigToBinaryBuffer(BigData* num, uint8_t* data, uint32_t maxBytes, uint32_t* bytes);
 
+void SBigXor(BigData* a, BigData* b, BigData* c);
+
 #endif

--- a/storm/Big.hpp
+++ b/storm/Big.hpp
@@ -12,6 +12,8 @@ void SBigBitLen(BigData* num, uint32_t* len);
 
 int32_t SBigCompare(BigData* a, BigData* b);
 
+void SBigCopy(BigData* a, BigData* b);
+
 void SBigDel(BigData* num);
 
 void SBigFromBinary(BigData* num, const void* data, uint32_t bytes);

--- a/storm/Big.hpp
+++ b/storm/Big.hpp
@@ -18,6 +18,8 @@ void SBigDec(BigData* a, BigData* b);
 
 void SBigDel(BigData* num);
 
+void SBigDiv(BigData* a, BigData* b, BigData* c);
+
 void SBigFromBinary(BigData* num, const void* data, uint32_t bytes);
 
 void SBigFromStr(BigData* num, const char* str);

--- a/storm/Big.hpp
+++ b/storm/Big.hpp
@@ -20,6 +20,8 @@ void SBigDel(BigData* num);
 
 void SBigFromBinary(BigData* num, const void* data, uint32_t bytes);
 
+void SBigFromStr(BigData* num, const char* str);
+
 void SBigFromUnsigned(BigData* num, uint32_t val);
 
 void SBigMod(BigData* a, BigData* b, BigData* c);

--- a/storm/big/Ops.cpp
+++ b/storm/big/Ops.cpp
@@ -483,6 +483,11 @@ void ToStream(TSGrowableArray<uint8_t>& output, const BigBuffer& buffer) {
     ToBinaryAppend(output, buffer);
 }
 
+void ToUnsigned(uint32_t* a, const BigBuffer& b) {
+    *a = 0;
+    *a = b[0];
+}
+
 void Xor(BigBuffer& a, const BigBuffer& b, const BigBuffer& c) {
     uint32_t i = 0;
     for (; b.IsUsed(i) || c.IsUsed(i); i++) {

--- a/storm/big/Ops.cpp
+++ b/storm/big/Ops.cpp
@@ -392,7 +392,20 @@ void Sub(BigBuffer& a, const BigBuffer& b, const BigBuffer& c) {
     }
 
     a.SetCount(i);
+    // This assert does not exist in retail WoW or Starcraft.
+    //STORM_ASSERT(!borrow);
+}
 
+void Sub(BigBuffer& a, const BigBuffer& b, uint32_t c) {
+    uint64_t borrow = 0;
+
+    uint32_t i = 0;
+    for (; b.IsUsed(i); i++) {
+        borrow += b[i] - static_cast<uint64_t>(c);;
+        a[i] = ExtractLowPartSx(borrow);
+    }
+
+    a.SetCount(i);
     // This assert does not exist in retail WoW or Starcraft.
     //STORM_ASSERT(!borrow);
 }

--- a/storm/big/Ops.cpp
+++ b/storm/big/Ops.cpp
@@ -52,12 +52,12 @@ void Div(BigBuffer& a, uint32_t* b, const BigBuffer& c, uint64_t d) {
     uint64_t data = 0;
     while (index > 0) {
         InsertLowPart(data, c[--index]);
-        a[index] = data / d;
+        a[index] = static_cast<uint32_t>(data / d);
         data %= d;
     }
 
     a.Trim();
-    *b = data;
+    *b = static_cast<uint32_t>(data);
 }
 
 void Div(BigBuffer& a, BigBuffer& b, const BigBuffer& c, const BigBuffer& d, BigStack& stack) {
@@ -102,7 +102,7 @@ void Div(BigBuffer& a, BigBuffer& b, const BigBuffer& c, const BigBuffer& d, Big
             cc.SetOffset(v12 - 1);
 
             if (t) {
-                a[0] = MakeLarge(cc[dCount - 1], cc[dCount]) / t;
+                a[0] = static_cast<uint32_t>(MakeLarge(cc[dCount - 1], cc[dCount]) / t);
             } else {
                 a[0] = cc[dCount];
             }
@@ -211,21 +211,21 @@ void InsertLowPart(uint64_t& value, uint32_t low) {
     value = (value << 32) | low;
 }
 
-int32_t IsEven(const BigBuffer &num) {
+int32_t IsEven(const BigBuffer& num) {
     return num.Count() == 0 || (num[0] & 1) == 0;
 }
 
-int32_t IsOdd(const BigBuffer &num) {
+int32_t IsOdd(const BigBuffer& num) {
     num.Trim();
     return num.Count() != 0 && (num[0] & 1) != 0;
 }
 
-int32_t IsOne(const BigBuffer &num) {
+int32_t IsOne(const BigBuffer& num) {
     num.Trim();
     return num.Count() == 1 && num[0] == 1;
 }
 
-int32_t IsZero(const BigBuffer &num) {
+int32_t IsZero(const BigBuffer& num) {
     num.Trim();
     return num.Count() == 0;
 }
@@ -437,8 +437,7 @@ void Sub(BigBuffer& a, const BigBuffer& b, const BigBuffer& c) {
     }
 
     a.SetCount(i);
-    // This assert does not exist in retail WoW or Starcraft.
-    //STORM_ASSERT(!borrow);
+    STORM_ASSERT(!borrow);
 }
 
 void Sub(BigBuffer& a, const BigBuffer& b, uint32_t c) {
@@ -451,8 +450,7 @@ void Sub(BigBuffer& a, const BigBuffer& b, uint32_t c) {
     }
 
     a.SetCount(i);
-    // This assert does not exist in retail WoW or Starcraft.
-    //STORM_ASSERT(!borrow);
+    STORM_ASSERT(!borrow);
 }
 
 void ToBinaryAppend(TSGrowableArray<uint8_t>& output, const BigBuffer& buffer) {

--- a/storm/big/Ops.cpp
+++ b/storm/big/Ops.cpp
@@ -482,3 +482,12 @@ void ToStream(TSGrowableArray<uint8_t>& output, const BigBuffer& buffer) {
     EncodeDataBytes(output, output.Count());
     ToBinaryAppend(output, buffer);
 }
+
+void Xor(BigBuffer& a, const BigBuffer& b, const BigBuffer& c) {
+    uint32_t i = 0;
+    for (; b.IsUsed(i) || c.IsUsed(i); i++) {
+        a[i] = c[i] ^ b[i];
+    }
+
+    a.SetCount(i);
+}

--- a/storm/big/Ops.cpp
+++ b/storm/big/Ops.cpp
@@ -215,6 +215,11 @@ int32_t IsEven(const BigBuffer &num) {
     return num.Count() == 0 || (num[0] & 1) == 0;
 }
 
+int32_t IsOdd(const BigBuffer &num) {
+    num.Trim();
+    return num.Count() != 0 && (num[0] & 1) != 0;
+}
+
 uint64_t MakeLarge(uint32_t low, uint32_t high) {
     return low + (static_cast<uint64_t>(high) << 32);
 }

--- a/storm/big/Ops.cpp
+++ b/storm/big/Ops.cpp
@@ -211,6 +211,10 @@ void InsertLowPart(uint64_t& value, uint32_t low) {
     value = (value << 32) | low;
 }
 
+int32_t IsEven(const BigBuffer &num) {
+    return num.Count() == 0 || (num[0] & 1) == 0;
+}
+
 uint64_t MakeLarge(uint32_t low, uint32_t high) {
     return low + (static_cast<uint64_t>(high) << 32);
 }

--- a/storm/big/Ops.cpp
+++ b/storm/big/Ops.cpp
@@ -22,6 +22,15 @@ void Add(BigBuffer& a, const BigBuffer& b, const BigBuffer& c) {
     a.SetCount(i);
 }
 
+void And(BigBuffer& a, const BigBuffer& b, const BigBuffer& c) {
+    uint32_t i = 0;
+    for (; b.IsUsed(i) || c.IsUsed(i); i++) {
+        a[i] = c[i] & b[i];
+    }
+
+    a.SetCount(i);
+}
+
 int32_t Compare(const BigBuffer& a, const BigBuffer& b) {
     int32_t result = 0;
 

--- a/storm/big/Ops.cpp
+++ b/storm/big/Ops.cpp
@@ -147,12 +147,11 @@ uint32_t ExtractLowPartLargeSum(uint64_t& value, uint64_t add) {
 }
 
 uint32_t ExtractLowPartSx(uint64_t& value) {
-    auto low = static_cast<uint32_t>(value);
+    uint32_t low = value & 0xFFFFFFFF;
     value >>= 32;
 
     if (value >= 0x80000000) {
-        reinterpret_cast<uint32_t*>(&value)[0] = value;
-        reinterpret_cast<uint32_t*>(&value)[1] = -1;
+        value |= 0xFFFFFFFFULL << 32;
     }
 
     return low;

--- a/storm/big/Ops.cpp
+++ b/storm/big/Ops.cpp
@@ -277,6 +277,15 @@ void MulMod(BigBuffer& a, const BigBuffer& b, const BigBuffer& c, const BigBuffe
     stack.Free(allocCount);
 }
 
+void Not(BigBuffer& a, const BigBuffer& b) {
+    uint32_t i = 0;
+    for (; b.IsUsed(i); i++) {
+        a[i] = ~b[i];
+    }
+
+    a.SetCount(i);
+}
+
 void PowMod(BigBuffer& a, const BigBuffer& b, const BigBuffer& c, const BigBuffer& d, BigStack& stack) {
     c.Trim();
 

--- a/storm/big/Ops.cpp
+++ b/storm/big/Ops.cpp
@@ -167,6 +167,14 @@ void FromBinary(BigBuffer& buffer, const void* data, uint32_t bytes) {
     }
 }
 
+void FromStr(BigBuffer& buffer, const char* str) {
+    SetZero(buffer);
+    for (; *str; str++) {
+        Mul(buffer, buffer, 10);
+        Add(buffer, buffer, *str - '0');
+    }
+}
+
 void FromUnsigned(BigBuffer& buffer, uint32_t value) {
     buffer[0] = value;
     buffer.SetCount(1);

--- a/storm/big/Ops.cpp
+++ b/storm/big/Ops.cpp
@@ -220,6 +220,11 @@ int32_t IsOdd(const BigBuffer &num) {
     return num.Count() != 0 && (num[0] & 1) != 0;
 }
 
+int32_t IsOne(const BigBuffer &num) {
+    num.Trim();
+    return num.Count() == 1 && num[0] == 1;
+}
+
 uint64_t MakeLarge(uint32_t low, uint32_t high) {
     return low + (static_cast<uint64_t>(high) << 32);
 }

--- a/storm/big/Ops.cpp
+++ b/storm/big/Ops.cpp
@@ -131,6 +131,15 @@ void Div(BigBuffer& a, BigBuffer& b, const BigBuffer& c, const BigBuffer& d, Big
     stack.Free(allocCount);
 }
 
+void EncodeDataBytes(TSGrowableArray<uint8_t>& output, uint32_t value) {
+    uint32_t v = value;
+    while (v != 0) {
+        *output.New() = v % 255u;
+        v /= 255u;
+    }
+    *output.New() = 255;
+}
+
 uint32_t ExtractLowPart(uint64_t& value) {
     auto low = static_cast<uint32_t>(value);
     value >>= 32;
@@ -465,5 +474,11 @@ void ToBinaryAppend(TSGrowableArray<uint8_t>& output, const BigBuffer& buffer) {
 
 void ToBinary(TSGrowableArray<uint8_t>& output, const BigBuffer& buffer) {
     output.SetCount(0);
+    ToBinaryAppend(output, buffer);
+}
+
+void ToStream(TSGrowableArray<uint8_t>& output, const BigBuffer& buffer) {
+    ToBinary(output, buffer);
+    EncodeDataBytes(output, output.Count());
     ToBinaryAppend(output, buffer);
 }

--- a/storm/big/Ops.cpp
+++ b/storm/big/Ops.cpp
@@ -286,6 +286,15 @@ void Not(BigBuffer& a, const BigBuffer& b) {
     a.SetCount(i);
 }
 
+void Or(BigBuffer& a, const BigBuffer& b, const BigBuffer& c) {
+    uint32_t i = 0;
+    for (; b.IsUsed(i) || c.IsUsed(i); i++) {
+        a[i] = c[i] | b[i];
+    }
+
+    a.SetCount(i);
+}
+
 void PowMod(BigBuffer& a, const BigBuffer& b, const BigBuffer& c, const BigBuffer& d, BigStack& stack) {
     c.Trim();
 

--- a/storm/big/Ops.cpp
+++ b/storm/big/Ops.cpp
@@ -225,6 +225,11 @@ int32_t IsOne(const BigBuffer &num) {
     return num.Count() == 1 && num[0] == 1;
 }
 
+int32_t IsZero(const BigBuffer &num) {
+    num.Trim();
+    return num.Count() == 0;
+}
+
 uint64_t MakeLarge(uint32_t low, uint32_t high) {
     return low + (static_cast<uint64_t>(high) << 32);
 }

--- a/storm/big/Ops.cpp
+++ b/storm/big/Ops.cpp
@@ -393,7 +393,8 @@ void Sub(BigBuffer& a, const BigBuffer& b, const BigBuffer& c) {
 
     a.SetCount(i);
 
-    STORM_ASSERT(!borrow);
+    // This assert does not exist in retail WoW or Starcraft.
+    //STORM_ASSERT(!borrow);
 }
 
 void ToBinaryAppend(TSGrowableArray<uint8_t>& output, const BigBuffer& buffer) {

--- a/storm/big/Ops.cpp
+++ b/storm/big/Ops.cpp
@@ -409,7 +409,7 @@ void Sub(BigBuffer& a, const BigBuffer& b, uint32_t c) {
 
     uint32_t i = 0;
     for (; b.IsUsed(i); i++) {
-        borrow += b[i] - static_cast<uint64_t>(c);;
+        borrow += b[i] - c;
         a[i] = ExtractLowPartSx(borrow);
     }
 

--- a/storm/big/Ops.hpp
+++ b/storm/big/Ops.hpp
@@ -75,6 +75,8 @@ void ToBinary(TSGrowableArray<uint8_t>& output, const BigBuffer& buffer);
 
 void ToStream(TSGrowableArray<uint8_t>& output, const BigBuffer& buffer);
 
+void ToUnsigned(uint32_t* a, const BigBuffer& b);
+
 void Xor(BigBuffer& a, const BigBuffer& b, const BigBuffer& c);
 
 #endif

--- a/storm/big/Ops.hpp
+++ b/storm/big/Ops.hpp
@@ -37,6 +37,8 @@ int32_t IsEven(const BigBuffer &num);
 
 int32_t IsOdd(const BigBuffer &num);
 
+int32_t IsOne(const BigBuffer &num);
+
 uint64_t MakeLarge(uint32_t low, uint32_t high);
 
 void Mul(BigBuffer& a, const BigBuffer& b, uint64_t c);

--- a/storm/big/Ops.hpp
+++ b/storm/big/Ops.hpp
@@ -35,6 +35,8 @@ void InsertLowPart(uint64_t& value, uint32_t low);
 
 int32_t IsEven(const BigBuffer &num);
 
+int32_t IsOdd(const BigBuffer &num);
+
 uint64_t MakeLarge(uint32_t low, uint32_t high);
 
 void Mul(BigBuffer& a, const BigBuffer& b, uint64_t c);

--- a/storm/big/Ops.hpp
+++ b/storm/big/Ops.hpp
@@ -39,6 +39,8 @@ int32_t IsOdd(const BigBuffer &num);
 
 int32_t IsOne(const BigBuffer &num);
 
+int32_t IsZero(const BigBuffer &num);
+
 uint64_t MakeLarge(uint32_t low, uint32_t high);
 
 void Mul(BigBuffer& a, const BigBuffer& b, uint64_t c);

--- a/storm/big/Ops.hpp
+++ b/storm/big/Ops.hpp
@@ -53,6 +53,8 @@ void Square(BigBuffer& a, const BigBuffer& b, BigStack& stack);
 
 void Sub(BigBuffer& a, const BigBuffer& b, const BigBuffer& c);
 
+void Sub(BigBuffer& a, const BigBuffer& b, uint32_t c);
+
 void ToBinary(TSGrowableArray<uint8_t>& output, const BigBuffer& buffer);
 
 #endif

--- a/storm/big/Ops.hpp
+++ b/storm/big/Ops.hpp
@@ -33,6 +33,8 @@ uint32_t HighBitPos(const BigBuffer& buffer);
 
 void InsertLowPart(uint64_t& value, uint32_t low);
 
+int32_t IsEven(const BigBuffer &num);
+
 uint64_t MakeLarge(uint32_t low, uint32_t high);
 
 void Mul(BigBuffer& a, const BigBuffer& b, uint64_t c);

--- a/storm/big/Ops.hpp
+++ b/storm/big/Ops.hpp
@@ -33,13 +33,13 @@ uint32_t HighBitPos(const BigBuffer& buffer);
 
 void InsertLowPart(uint64_t& value, uint32_t low);
 
-int32_t IsEven(const BigBuffer &num);
+int32_t IsEven(const BigBuffer& num);
 
-int32_t IsOdd(const BigBuffer &num);
+int32_t IsOdd(const BigBuffer& num);
 
-int32_t IsOne(const BigBuffer &num);
+int32_t IsOne(const BigBuffer& num);
 
-int32_t IsZero(const BigBuffer &num);
+int32_t IsZero(const BigBuffer& num);
 
 uint64_t MakeLarge(uint32_t low, uint32_t high);
 

--- a/storm/big/Ops.hpp
+++ b/storm/big/Ops.hpp
@@ -49,6 +49,8 @@ void Mul(BigBuffer& a, const BigBuffer& b, const BigBuffer& c, BigStack& stack);
 
 void MulMod(BigBuffer& a, const BigBuffer& b, const BigBuffer& c, const BigBuffer& d, BigStack& stack);
 
+void Not(BigBuffer& a, const BigBuffer& b);
+
 void PowMod(BigBuffer& a, const BigBuffer& b, const BigBuffer& c, const BigBuffer& d, BigStack& stack);
 
 void SetOne(BigBuffer& buffer);

--- a/storm/big/Ops.hpp
+++ b/storm/big/Ops.hpp
@@ -51,6 +51,8 @@ void MulMod(BigBuffer& a, const BigBuffer& b, const BigBuffer& c, const BigBuffe
 
 void Not(BigBuffer& a, const BigBuffer& b);
 
+void Or(BigBuffer& a, const BigBuffer& b, const BigBuffer& c);
+
 void PowMod(BigBuffer& a, const BigBuffer& b, const BigBuffer& c, const BigBuffer& d, BigStack& stack);
 
 void SetOne(BigBuffer& buffer);

--- a/storm/big/Ops.hpp
+++ b/storm/big/Ops.hpp
@@ -25,6 +25,8 @@ uint32_t ExtractLowPartSx(uint64_t& value);
 
 void FromBinary(BigBuffer& buffer, const void* value, uint32_t bytes);
 
+void FromStr(BigBuffer& buffer, const char* str);
+
 void FromUnsigned(BigBuffer& buffer, uint32_t value);
 
 uint32_t HighBitPos(const BigBuffer& buffer);

--- a/storm/big/Ops.hpp
+++ b/storm/big/Ops.hpp
@@ -9,6 +9,8 @@ void Add(BigBuffer& a, const BigBuffer& b, uint32_t c);
 
 void Add(BigBuffer& a, const BigBuffer& b, const BigBuffer& c);
 
+void And(BigBuffer& a, const BigBuffer& b, const BigBuffer& c);
+
 int32_t Compare(const BigBuffer& a, const BigBuffer& b);
 
 void Div(BigBuffer& a, uint32_t* b, const BigBuffer& c, uint64_t d);

--- a/storm/big/Ops.hpp
+++ b/storm/big/Ops.hpp
@@ -75,4 +75,6 @@ void ToBinary(TSGrowableArray<uint8_t>& output, const BigBuffer& buffer);
 
 void ToStream(TSGrowableArray<uint8_t>& output, const BigBuffer& buffer);
 
+void Xor(BigBuffer& a, const BigBuffer& b, const BigBuffer& c);
+
 #endif

--- a/storm/big/Ops.hpp
+++ b/storm/big/Ops.hpp
@@ -17,6 +17,8 @@ void Div(BigBuffer& a, uint32_t* b, const BigBuffer& c, uint64_t d);
 
 void Div(BigBuffer& a, BigBuffer& b, const BigBuffer& c, const BigBuffer& d, BigStack& stack);
 
+void EncodeDataBytes(TSGrowableArray<uint8_t>& output, uint32_t value);
+
 uint32_t ExtractLowPart(uint64_t& value);
 
 uint32_t ExtractLowPartLargeSum(uint64_t& value, uint64_t add);
@@ -70,5 +72,7 @@ void Sub(BigBuffer& a, const BigBuffer& b, const BigBuffer& c);
 void Sub(BigBuffer& a, const BigBuffer& b, uint32_t c);
 
 void ToBinary(TSGrowableArray<uint8_t>& output, const BigBuffer& buffer);
+
+void ToStream(TSGrowableArray<uint8_t>& output, const BigBuffer& buffer);
 
 #endif

--- a/storm/thread/S_Thread.hpp
+++ b/storm/thread/S_Thread.hpp
@@ -42,7 +42,7 @@ class S_Thread {
 
     // Static functions
 #if defined(WHOA_SYSTEM_WIN)
-    static DWORD s_SLaunchThread(void* threadParam);
+    static DWORD WINAPI s_SLaunchThread(void* threadParam);
 #endif
 
 #if defined(WHOA_SYSTEM_MAC)

--- a/storm/thread/win/S_Thread.cpp
+++ b/storm/thread/win/S_Thread.cpp
@@ -1,7 +1,11 @@
 #include "storm/thread/S_Thread.hpp"
 #include "storm/Memory.hpp"
 
-DWORD S_Thread::s_SLaunchThread(void* threadParam) {
+#ifndef WINAPI
+#define WINAPI
+#endif
+
+DWORD WINAPI S_Thread::s_SLaunchThread(void* threadParam) {
     auto params = static_cast<SThreadParmBlock*>(threadParam);
     auto proc = params->threadProc;
     auto param = params->threadParam;

--- a/storm/thread/win/S_Thread.cpp
+++ b/storm/thread/win/S_Thread.cpp
@@ -1,10 +1,6 @@
 #include "storm/thread/S_Thread.hpp"
 #include "storm/Memory.hpp"
 
-#ifndef WINAPI
-#define WINAPI
-#endif
-
 DWORD WINAPI S_Thread::s_SLaunchThread(void* threadParam) {
     auto params = static_cast<SThreadParmBlock*>(threadParam);
     auto proc = params->threadProc;

--- a/test/Big.cpp
+++ b/test/Big.cpp
@@ -231,6 +231,29 @@ TEST_CASE("SBigCopy", "[big]") {
     }
 }
 
+TEST_CASE("SBigDec", "[big]") {
+    BigDataTest a;
+    BigDataTest b;
+
+    SECTION("decrements value by 1") {
+        SBigFromUnsigned(b, 5);
+
+        SBigDec(a, b);
+
+        CHECK(a->Primary().Count() == 1);
+        CHECK(a->Primary()[0] == 4);
+    }
+
+    SECTION("decrements from 0") {
+        SBigFromUnsigned(b, 0);
+
+        SBigDec(a, b);
+
+        CHECK(a->Primary().Count() == 1);
+        CHECK(a->Primary()[0] == 0xFFFFFFFF);
+    }
+}
+
 TEST_CASE("SBigFromBinary", "[big]") {
     SECTION("creates bigdata from 0") {
         BigData* num;
@@ -569,16 +592,10 @@ TEST_CASE("SBigSquare", "[big]") {
 }
 
 TEST_CASE("SBigSub", "[big]") {
+    BigDataTest a, b, c;
+
     SECTION("subtracts 1 from 2") {
-        BigData* a;
-        SBigNew(&a);
-
-        BigData* b;
-        SBigNew(&b);
         SBigFromUnsigned(b, 2);
-
-        BigData* c;
-        SBigNew(&c);
         SBigFromUnsigned(c, 1);
 
         SBigSub(a, b, c);
@@ -587,9 +604,16 @@ TEST_CASE("SBigSub", "[big]") {
 
         CHECK(a->Primary().Count() == 1);
         CHECK(a->Primary()[0] == 1);
+    }
 
-        SBigDel(a);
-        SBigDel(b);
+    SECTION("subtracts 1 from 0") {
+        SBigFromUnsigned(b, 0);
+        SBigFromUnsigned(c, 1);
+
+        SBigSub(a, b, c);
+
+        CHECK(a->Primary().Count() == 1);
+        CHECK(a->Primary()[0] == 0xFFFFFFFF);
     }
 }
 

--- a/test/Big.cpp
+++ b/test/Big.cpp
@@ -3,82 +3,40 @@
 #include <string>
 
 TEST_CASE("SBigAdd", "[big]") {
+    BigDataTest a, b, c;
+
     SECTION("adds 0 and 1") {
-        BigData* a;
-        SBigNew(&a);
-
-        BigData* b;
-        SBigNew(&b);
         SBigFromUnsigned(b, 0);
-
-        BigData* c;
-        SBigNew(&c);
         SBigFromUnsigned(c, 1);
 
         SBigAdd(a, b, c);
 
         CHECK(a->Primary().Count() == 1);
         CHECK(a->Primary()[0] == 1);
-
-        SBigDel(a);
-        SBigDel(b);
-        SBigDel(c);
     }
 
     SECTION("adds 1 and 2") {
-        BigData* a;
-        SBigNew(&a);
-
-        BigData* b;
-        SBigNew(&b);
         SBigFromUnsigned(b, 1);
-
-        BigData* c;
-        SBigNew(&c);
         SBigFromUnsigned(c, 2);
 
         SBigAdd(a, b, c);
 
         CHECK(a->Primary().Count() == 1);
         CHECK(a->Primary()[0] == 3);
-
-        SBigDel(a);
-        SBigDel(b);
-        SBigDel(c);
     }
 
     SECTION("adds 0x12345678 and 0x23456789") {
-        BigData* a;
-        SBigNew(&a);
-
-        BigData* b;
-        SBigNew(&b);
         SBigFromUnsigned(b, 0x12345678);
-
-        BigData* c;
-        SBigNew(&c);
         SBigFromUnsigned(c, 0x23456789);
 
         SBigAdd(a, b, c);
 
         CHECK(a->Primary().Count() == 1);
         CHECK(a->Primary()[0] == 0x3579BE01);
-
-        SBigDel(a);
-        SBigDel(b);
-        SBigDel(c);
     }
 
     SECTION("adds 0xFFFFFFFF and 0xF0F0F0F0") {
-        BigData* a;
-        SBigNew(&a);
-
-        BigData* b;
-        SBigNew(&b);
         SBigFromUnsigned(b, 0xFFFFFFFF);
-
-        BigData* c;
-        SBigNew(&c);
         SBigFromUnsigned(c, 0xF0F0F0F0);
 
         SBigAdd(a, b, c);
@@ -86,17 +44,11 @@ TEST_CASE("SBigAdd", "[big]") {
         CHECK(a->Primary().Count() == 2);
         CHECK(a->Primary()[0] == 0xF0F0F0EF);
         CHECK(a->Primary()[1] == 0x1);
-
-        SBigDel(a);
-        SBigDel(b);
-        SBigDel(c);
     }
 }
 
 TEST_CASE("SBigAnd", "[big]") {
-    BigDataTest a;
-    BigDataTest b;
-    BigDataTest c;
+    BigDataTest a, b, c;
 
     SECTION("overwrites output") {
         SBigFromUnsigned(a, 123456);
@@ -130,61 +82,45 @@ TEST_CASE("SBigAnd", "[big]") {
 }
 
 TEST_CASE("SBigBitLen", "[big]") {
+    BigDataTest num;
+
     SECTION("returns bit length of 1") {
-        BigData* num;
-        SBigNew(&num);
         SBigFromUnsigned(num, 1);
 
         uint32_t len;
         SBigBitLen(num, &len);
 
         CHECK(len == 1);
-
-        SBigDel(num);
     }
 
     SECTION("returns bit length of 5") {
-        BigData* num;
-        SBigNew(&num);
         SBigFromUnsigned(num, 5);
 
         uint32_t len;
         SBigBitLen(num, &len);
 
         CHECK(len == 3);
-
-        SBigDel(num);
     }
 
     SECTION("returns bit length of 0xFFFF") {
-        BigData* num;
-        SBigNew(&num);
         SBigFromUnsigned(num, 0xFFFF);
 
         uint32_t len;
         SBigBitLen(num, &len);
 
         CHECK(len == 16);
-
-        SBigDel(num);
     }
 
     SECTION("returns bit length of 0xFFFFFFFF") {
-        BigData* num;
-        SBigNew(&num);
         SBigFromUnsigned(num, 0xFFFFFFFF);
 
         uint32_t len;
         SBigBitLen(num, &len);
 
         CHECK(len == 32);
-
-        SBigDel(num);
     }
 
     SECTION("returns bit length of 0x22222222AAAAAAAA") {
-        BigData* num;
-        SBigNew(&num);
         uint64_t num_ = 0x22222222AAAAAAAA;
         SBigFromBinary(num, reinterpret_cast<uint8_t*>(&num_), sizeof(num_));
 
@@ -192,25 +128,17 @@ TEST_CASE("SBigBitLen", "[big]") {
         SBigBitLen(num, &len);
 
         CHECK(len == 62);
-
-        SBigDel(num);
     }
 }
 
 TEST_CASE("SBigCompare", "[big]") {
-    SECTION("compares 10 and 1") {
-        BigData* a;
-        SBigNew(&a);
-        SBigFromUnsigned(a, 10);
+    BigDataTest a, b;
 
-        BigData* b;
-        SBigNew(&b);
+    SECTION("compares 10 and 1") {
+        SBigFromUnsigned(a, 10);
         SBigFromUnsigned(b, 1);
 
         CHECK(SBigCompare(a, b) == 1);
-
-        SBigDel(a);
-        SBigDel(b);
     }
 }
 
@@ -319,29 +247,23 @@ TEST_CASE("SBigDiv", "[big]") {
 }
 
 TEST_CASE("SBigFromBinary", "[big]") {
+    BigDataTest num;
+
     SECTION("creates bigdata from 0") {
-        BigData* num;
-        SBigNew(&num);
         uint32_t data = 0;
         SBigFromBinary(num, reinterpret_cast<uint8_t*>(&data), sizeof(data));
 
         CHECK(num->Primary().Count() == 1);
         CHECK(num->Primary()[0] == 0);
-
-        SBigDel(num);
     }
 
     SECTION("creates bigdata from 0x123456789ABCDEF0") {
-        BigData* num;
-        SBigNew(&num);
         uint64_t data = 0x123456789ABCDEF0;
         SBigFromBinary(num, reinterpret_cast<uint8_t*>(&data), sizeof(data));
 
         CHECK(num->Primary().Count() == 2);
         CHECK(num->Primary()[0] == 0x9ABCDEF0);
         CHECK(num->Primary()[1] == 0x12345678);
-
-        SBigDel(num);
     }
 }
 
@@ -372,26 +294,20 @@ TEST_CASE("SBigFromStr", "[big]") {
 }
 
 TEST_CASE("SBigFromUnsigned", "[big]") {
+    BigDataTest num;
+
     SECTION("creates bigdata from 0") {
-        BigData* num;
-        SBigNew(&num);
         SBigFromUnsigned(num, 0);
 
         CHECK(num->Primary().Count() == 1);
         CHECK(num->Primary()[0] == 0);
-
-        SBigDel(num);
     }
 
     SECTION("creates bigdata from 0x12345678") {
-        BigData* num;
-        SBigNew(&num);
         SBigFromUnsigned(num, 0x12345678);
 
         CHECK(num->Primary().Count() == 1);
         CHECK(num->Primary()[0] == 0x12345678);
-
-        SBigDel(num);
     }
 }
 TEST_CASE("SBigInc", "[big]") {
@@ -507,16 +423,9 @@ TEST_CASE("SBigIsZero", "[big]") {
 }
 
 TEST_CASE("SBigMod", "[big]") {
+    BigDataTest a, b, c;
     SECTION("mods 7 by 4") {
-        BigData* a;
-        SBigNew(&a);
-
-        BigData* b;
-        SBigNew(&b);
         SBigFromUnsigned(b, 7);
-
-        BigData* c;
-        SBigNew(&c);
         SBigFromUnsigned(c, 4);
 
         SBigMod(a, b, c);
@@ -525,30 +434,14 @@ TEST_CASE("SBigMod", "[big]") {
 
         CHECK(a->Primary().Count() == 1);
         CHECK(a->Primary()[0] == 3);
-
-        SBigDel(a);
-        SBigDel(b);
-        SBigDel(c);
     }
 
     SECTION("mods 7 by 4 then mods 9 by 5") {
-        BigData* a;
-        SBigNew(&a);
+        BigDataTest b1, c1, b2, c2;
 
-        BigData* b1;
-        SBigNew(&b1);
         SBigFromUnsigned(b1, 7);
-
-        BigData* c1;
-        SBigNew(&c1);
         SBigFromUnsigned(c1, 4);
-
-        BigData* b2;
-        SBigNew(&b2);
         SBigFromUnsigned(b2, 9);
-
-        BigData* c2;
-        SBigNew(&c2);
         SBigFromUnsigned(c2, 5);
 
         SBigMod(a, b1, c1);
@@ -564,25 +457,11 @@ TEST_CASE("SBigMod", "[big]") {
 
         CHECK(a->Primary().Count() == 1);
         CHECK(a->Primary()[0] == 4);
-
-        SBigDel(a);
-        SBigDel(b1);
-        SBigDel(c1);
-        SBigDel(b2);
-        SBigDel(c2);
     }
 
     SECTION("mods 0x9999444488885555 by 0xFFFFFFFF") {
-        BigData* a;
-        SBigNew(&a);
-
-        BigData* b;
-        SBigNew(&b);
         uint64_t b_ = 0x9999444488885555;
         SBigFromBinary(b, reinterpret_cast<uint8_t*>(&b_), sizeof(b_));
-
-        BigData* c;
-        SBigNew(&c);
         SBigFromUnsigned(c, 0xFFFFFFFF);
 
         SBigMod(a, b, c);
@@ -591,24 +470,14 @@ TEST_CASE("SBigMod", "[big]") {
 
         CHECK(a->Primary().Count() == 1);
         CHECK(a->Primary()[0] == 0x2221999A);
-
-        SBigDel(a);
-        SBigDel(b);
-        SBigDel(c);
     }
 }
 
 TEST_CASE("SBigMul", "[big]") {
+    BigDataTest a, b, c;
+
     SECTION("multiplies 0 and 1") {
-        BigData* a;
-        SBigNew(&a);
-
-        BigData* b;
-        SBigNew(&b);
         SBigFromUnsigned(b, 0);
-
-        BigData* c;
-        SBigNew(&c);
         SBigFromUnsigned(c, 1);
 
         SBigMul(a, b, c);
@@ -616,22 +485,10 @@ TEST_CASE("SBigMul", "[big]") {
         a->Primary().Trim();
 
         CHECK(a->Primary().Count() == 0);
-
-        SBigDel(a);
-        SBigDel(b);
-        SBigDel(c);
     }
 
     SECTION("multiplies 2 and 4") {
-        BigData* a;
-        SBigNew(&a);
-
-        BigData* b;
-        SBigNew(&b);
         SBigFromUnsigned(b, 2);
-
-        BigData* c;
-        SBigNew(&c);
         SBigFromUnsigned(c, 4);
 
         SBigMul(a, b, c);
@@ -640,22 +497,10 @@ TEST_CASE("SBigMul", "[big]") {
 
         CHECK(a->Primary().Count() == 1);
         CHECK(a->Primary()[0] == 8);
-
-        SBigDel(a);
-        SBigDel(b);
-        SBigDel(c);
     }
 
     SECTION("multiplies 0xFFFFFFFF and 0x100") {
-        BigData* a;
-        SBigNew(&a);
-
-        BigData* b;
-        SBigNew(&b);
         SBigFromUnsigned(b, 0xFFFFFFFF);
-
-        BigData* c;
-        SBigNew(&c);
         SBigFromUnsigned(c, 0x100);
 
         SBigMul(a, b, c);
@@ -665,22 +510,10 @@ TEST_CASE("SBigMul", "[big]") {
         CHECK(a->Primary().Count() == 2);
         CHECK(a->Primary()[0] == 0xFFFFFF00);
         CHECK(a->Primary()[1] == 0xFF);
-
-        SBigDel(a);
-        SBigDel(b);
-        SBigDel(c);
     }
 
     SECTION("multiplies 0xFFFFFF and 0x11223344") {
-        BigData* a;
-        SBigNew(&a);
-
-        BigData* b;
-        SBigNew(&b);
         SBigFromUnsigned(b, 0xFFFFFF);
-
-        BigData* c;
-        SBigNew(&c);
         SBigFromUnsigned(c, 0x11223344);
 
         SBigMul(a, b, c);
@@ -690,28 +523,14 @@ TEST_CASE("SBigMul", "[big]") {
         CHECK(a->Primary().Count() == 2);
         CHECK(a->Primary()[0] == 0x32DDCCBC);
         CHECK(a->Primary()[1] == 0x112233);
-
-        SBigDel(a);
-        SBigDel(b);
-        SBigDel(c);
     }
 }
 
 TEST_CASE("SBigPowMod", "[big]") {
+    BigDataTest a, b, c, d;
     SECTION("takes 256 to the 8th power and mods the result by 999") {
-        BigData* a;
-        SBigNew(&a);
-
-        BigData* b;
-        SBigNew(&b);
         SBigFromUnsigned(b, 256);
-
-        BigData* c;
-        SBigNew(&c);
         SBigFromUnsigned(c, 8);
-
-        BigData* d;
-        SBigNew(&d);
         SBigFromUnsigned(d, 999);
 
         SBigPowMod(a, b, c, d);
@@ -720,11 +539,6 @@ TEST_CASE("SBigPowMod", "[big]") {
 
         CHECK(a->Primary().Count() == 1);
         CHECK(a->Primary()[0] == 160);
-
-        SBigDel(a);
-        SBigDel(b);
-        SBigDel(c);
-        SBigDel(d);
     }
 }
 
@@ -820,12 +634,9 @@ TEST_CASE("SBigOr", "[big]") {
 }
 
 TEST_CASE("SBigShl", "[big]") {
-    SECTION("shifts 256 left 7 bits") {
-        BigData* a;
-        SBigNew(&a);
+    BigDataTest a, b;
 
-        BigData* b;
-        SBigNew(&b);
+    SECTION("shifts 256 left 7 bits") {
         SBigFromUnsigned(b, 256);
 
         SBigShl(a, b, 7);
@@ -834,19 +645,13 @@ TEST_CASE("SBigShl", "[big]") {
 
         CHECK(a->Primary().Count() == 1);
         CHECK(a->Primary()[0] == 32768);
-
-        SBigDel(a);
-        SBigDel(b);
     }
 }
 
 TEST_CASE("SBigShr", "[big]") {
-    SECTION("shifts 256 right 7 bits") {
-        BigData* a;
-        SBigNew(&a);
+    BigDataTest a, b;
 
-        BigData* b;
-        SBigNew(&b);
+    SECTION("shifts 256 right 7 bits") {
         SBigFromUnsigned(b, 256);
 
         SBigShr(a, b, 7);
@@ -855,19 +660,13 @@ TEST_CASE("SBigShr", "[big]") {
 
         CHECK(a->Primary().Count() == 1);
         CHECK(a->Primary()[0] == 2);
-
-        SBigDel(a);
-        SBigDel(b);
     }
 }
 
 TEST_CASE("SBigSquare", "[big]") {
-    SECTION("squares 0xFFFFFFFF") {
-        BigData* a;
-        SBigNew(&a);
+    BigDataTest a, b;
 
-        BigData* b;
-        SBigNew(&b);
+    SECTION("squares 0xFFFFFFFF") {
         SBigFromUnsigned(b, 0xFFFFFFFF);
 
         SBigSquare(a, b);
@@ -877,9 +676,6 @@ TEST_CASE("SBigSquare", "[big]") {
         CHECK(a->Primary().Count() == 2);
         CHECK(a->Primary()[0] == 0x1);
         CHECK(a->Primary()[1] == 0xFFFFFFFE);
-
-        SBigDel(a);
-        SBigDel(b);
     }
 }
 
@@ -910,9 +706,9 @@ TEST_CASE("SBigSub", "[big]") {
 }
 
 TEST_CASE("SBigToBinaryBuffer", "[big]") {
+    BigDataTest num;
+
     SECTION("returns expected buffer for bigdata representing 0") {
-        BigData* num;
-        SBigNew(&num);
         SBigFromUnsigned(num, 0);
 
         uint8_t buffer[4];
@@ -920,13 +716,9 @@ TEST_CASE("SBigToBinaryBuffer", "[big]") {
         SBigToBinaryBuffer(num, buffer, sizeof(buffer), &bytes);
 
         REQUIRE(bytes == 0);
-
-        SBigDel(num);
     }
 
     SECTION("returns expected buffer for bigdata representing 0x12345678") {
-        BigData* num;
-        SBigNew(&num);
         SBigFromUnsigned(num, 0x12345678);
 
         uint8_t buffer[4];
@@ -935,13 +727,9 @@ TEST_CASE("SBigToBinaryBuffer", "[big]") {
 
         CHECK(bytes == 4);
         CHECK(*reinterpret_cast<uint32_t*>(buffer) == 0x12345678);
-
-        SBigDel(num);
     }
 
     SECTION("returns expected buffer for bigdata representing 0x123456789ABCDEF0") {
-        BigData* num;
-        SBigNew(&num);
         uint64_t data = 0x123456789ABCDEF0;
         SBigFromBinary(num, reinterpret_cast<uint8_t*>(&data), sizeof(data));
 
@@ -951,7 +739,5 @@ TEST_CASE("SBigToBinaryBuffer", "[big]") {
 
         CHECK(bytes == 8);
         CHECK(*reinterpret_cast<uint64_t*>(buffer) == 0x123456789ABCDEF0);
-
-        SBigDel(num);
     }
 }

--- a/test/Big.cpp
+++ b/test/Big.cpp
@@ -426,6 +426,28 @@ TEST_CASE("SBigInc", "[big]") {
     }
 }
 
+TEST_CASE("SBigIsEven", "[big]") {
+    BigDataTest a;
+
+    SECTION("unset zero is even") {
+        CHECK(SBigIsEven(a));
+    }
+
+    SECTION("numbers are even") {
+        auto v = GENERATE(0ULL, 2ULL, 10ULL, 10000ULL, 0xFFFFFFFEULL, 0x9999888877776666ULL);
+
+        SBigFromStr(a, std::to_string(v).c_str());
+        CHECK(SBigIsEven(a));
+    }
+
+    SECTION("numbers are not even") {
+        auto v = GENERATE(1ULL, 3ULL, 37ULL, 999999999ULL, 0xFFFFFFFFFULL, 0x9999888877776667ULL);
+
+        SBigFromStr(a, std::to_string(v).c_str());
+        CHECK_FALSE(SBigIsEven(a));
+    }
+}
+
 TEST_CASE("SBigMod", "[big]") {
     SECTION("mods 7 by 4") {
         BigData* a;

--- a/test/Big.cpp
+++ b/test/Big.cpp
@@ -745,3 +745,49 @@ TEST_CASE("SBigToBinaryBuffer", "[big]") {
         CHECK(*reinterpret_cast<uint64_t*>(buffer) == 0x123456789ABCDEF0);
     }
 }
+
+TEST_CASE("SBigXor", "[big]") {
+    BigDataTest a, b, c;
+
+    SECTION("performs bitwise xor on small numbers") {
+        auto v = GENERATE(
+            std::make_pair(0UL, 0UL),
+            std::make_pair(0UL, 123UL),
+            std::make_pair(41689UL, 786740UL)
+        );
+
+        SBigFromUnsigned(b, v.first);
+        SBigFromUnsigned(c, v.second);
+        SBigXor(a, b, c);
+
+        CHECK(a->Primary().Count() == 1);
+        CHECK(a->Primary()[0] == (v.first ^ v.second));
+    }
+
+    SECTION("performs bitwise xor on large number") {
+        SBigFromStr(b, std::to_string(0xFF00FF00FF00FF00ULL).c_str());
+        SBigFromStr(c, std::to_string(0xFF00FF00FF00FULL).c_str());
+        SBigXor(a, b, c);
+
+        CHECK(a->Primary().Count() == 2);
+        CHECK(a->Primary()[0] == 0xF0F0F0F);
+        CHECK(a->Primary()[1] == 0xFF0F0F0F);
+    }
+
+    SECTION("performs bitwise xor on huge value") {
+        uint32_t data[] = { 0xF00DFEEDUL, 0xBA1DUL, 0xBEEBBEEBUL, 0x12345678UL, 0x9ABCDEFUL, 0xDEADCADUL, 0xD011AUL };
+
+        SBigFromBinary(b, data, sizeof(data));
+        SBigFromUnsigned(c, 0x1111111FUL);
+        SBigXor(a, b, c);
+
+        CHECK(a->Primary().Count() == 7);
+        CHECK(a->Primary()[0] == 0xE11CEFF2);
+        CHECK(a->Primary()[1] == data[1]);
+        CHECK(a->Primary()[2] == data[2]);
+        CHECK(a->Primary()[3] == data[3]);
+        CHECK(a->Primary()[4] == data[4]);
+        CHECK(a->Primary()[5] == data[5]);
+        CHECK(a->Primary()[6] == data[6]);
+    }
+}

--- a/test/Big.cpp
+++ b/test/Big.cpp
@@ -769,6 +769,56 @@ TEST_CASE("SBigNot", "[big]") {
     }
 }
 
+TEST_CASE("SBigOr", "[big]") {
+    BigDataTest a, b, c;
+
+    SECTION("performs bitwise or on small numbers") {
+        auto v = GENERATE(
+            std::make_pair(0UL, 0UL),
+            std::make_pair(0UL, 123UL),
+            std::make_pair(41689UL, 786740UL)
+        );
+
+        SBigFromUnsigned(b, v.first);
+        SBigFromUnsigned(c, v.second);
+        SBigOr(a, b, c);
+
+        CHECK(a->Primary().Count() == 1);
+        CHECK(a->Primary()[0] == (v.first | v.second));
+    }
+
+    SECTION("performs bitwise or on large numbers") {
+        auto v = GENERATE(
+            std::make_pair(0xFF00FF00FF00FF00ULL, 0xFF00FF00FF00FFULL)
+        );
+
+        SBigFromStr(b, std::to_string(v.first).c_str());
+        SBigFromStr(c, std::to_string(v.second).c_str());
+        SBigOr(a, b, c);
+
+        CHECK(a->Primary().Count() == 2);
+        CHECK(a->Primary()[0] == uint32_t(v.first | v.second));
+        CHECK(a->Primary()[1] == uint32_t((v.first | v.second) >> 32));
+    }
+
+    SECTION("performs bitwise or on huge value") {
+        uint32_t data[] = { 0xF00DFEEDUL, 0xBA1DUL, 0xBEEBBEEBUL, 0x12345678UL, 0x9ABCDEFUL, 0xDEADCADUL, 0xD011AUL };
+
+        SBigFromBinary(b, data, sizeof(data));
+        SBigFromUnsigned(c, 0x11111111UL);
+        SBigOr(a, b, c);
+
+        CHECK(a->Primary().Count() == 7);
+        CHECK(a->Primary()[0] == 0xF11DFFFD);
+        CHECK(a->Primary()[1] == data[1]);
+        CHECK(a->Primary()[2] == data[2]);
+        CHECK(a->Primary()[3] == data[3]);
+        CHECK(a->Primary()[4] == data[4]);
+        CHECK(a->Primary()[5] == data[5]);
+        CHECK(a->Primary()[6] == data[6]);
+    }
+}
+
 TEST_CASE("SBigShl", "[big]") {
     SECTION("shifts 256 left 7 bits") {
         BigData* a;

--- a/test/Big.cpp
+++ b/test/Big.cpp
@@ -1,5 +1,6 @@
 #include "storm/Big.hpp"
 #include "test/Test.hpp"
+#include <string>
 
 TEST_CASE("SBigAdd", "[big]") {
     SECTION("adds 0 and 1") {
@@ -214,8 +215,7 @@ TEST_CASE("SBigCompare", "[big]") {
 }
 
 TEST_CASE("SBigCopy", "[big]") {
-    BigDataTest a;
-    BigDataTest b;
+    BigDataTest a, b;
 
     SECTION("copies data") {
         uint8_t num[] = { 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9 };
@@ -232,8 +232,7 @@ TEST_CASE("SBigCopy", "[big]") {
 }
 
 TEST_CASE("SBigDec", "[big]") {
-    BigDataTest a;
-    BigDataTest b;
+    BigDataTest a, b;
 
     SECTION("decrements value by 1") {
         SBigFromUnsigned(b, 5);
@@ -251,6 +250,71 @@ TEST_CASE("SBigDec", "[big]") {
 
         CHECK(a->Primary().Count() == 1);
         CHECK(a->Primary()[0] == 0xFFFFFFFF);
+    }
+}
+
+TEST_CASE("SBigDiv", "[big]") {
+    BigDataTest a, b, c;
+
+    SECTION("divides 2 by 1") {
+        SBigFromUnsigned(b, 2);
+        SBigFromUnsigned(c, 1);
+
+        SBigDiv(a, b, c);
+
+        CHECK(a->Primary().Count() == 1);
+        CHECK(a->Primary()[0] == 2);
+    }
+
+    SECTION("divides 5 by 2") {
+        SBigFromUnsigned(b, 5);
+        SBigFromUnsigned(c, 2);
+
+        SBigDiv(a, b, c);
+
+        CHECK(a->Primary().Count() == 1);
+        CHECK(a->Primary()[0] == 2);
+    }
+
+    SECTION("divides 7 by 4") {
+        SBigFromUnsigned(b, 7);
+        SBigFromUnsigned(c, 4);
+
+        SBigDiv(a, b, c);
+
+        CHECK(a->Primary().Count() == 1);
+        CHECK(a->Primary()[0] == 1);
+    }
+
+    SECTION("divides 0x9999444488885555 by 0x2222") {
+        SBigFromStr(b, std::to_string(0x9999444488885555ULL).c_str());
+        SBigFromUnsigned(c, 0x2222);
+
+        SBigDiv(a, b, c);
+
+        CHECK(a->Primary().Count() == 2);
+        CHECK(a->Primary()[0] == 0x00040002);
+        CHECK(a->Primary()[1] == 0x48002);
+    }
+
+    SECTION("divides 0x9999444488885555 by 0xFFFFFFFF") {
+        SBigFromStr(b, std::to_string(0x9999444488885555ULL).c_str());
+        SBigFromUnsigned(c, 0xFFFFFFFF);
+
+        SBigDiv(a, b, c);
+
+        CHECK(a->Primary().Count() == 1);
+        CHECK(a->Primary()[0] == 0x99994445);
+    }
+
+    SECTION("divides 0x9999444488885555 by 0x1111222233334444 (buffer divisor)") {
+        SBigFromStr(b, std::to_string(0x9999444488885555ULL).c_str());
+        SBigFromStr(c, std::to_string(0x1111222233334444ULL).c_str());
+
+        SBigDiv(a, b, c);
+
+        CHECK(a->Primary().Count() == 1);
+        CHECK(a->Primary()[0] == 8);
     }
 }
 

--- a/test/Big.cpp
+++ b/test/Big.cpp
@@ -281,6 +281,32 @@ TEST_CASE("SBigFromBinary", "[big]") {
     }
 }
 
+TEST_CASE("SBigFromStr", "[big]") {
+    BigDataTest num;
+
+    SECTION("with empty string") {
+        SBigFromStr(num, "");
+
+        CHECK(num->Primary().Count() == 0);
+    }
+
+    SECTION("with string containing numbers") {
+        SBigFromStr(num, "123456");
+
+        CHECK(num->Primary().Count() == 1);
+        CHECK(num->Primary()[0] == 123456);
+    }
+
+    SECTION("with string containing letters (original bug)") {
+        SBigFromStr(num, "ABC");
+
+        const unsigned int expected_num = ('A' - '0') * 100 + ('B' - '0') * 10 + ('C' - '0');
+
+        CHECK(num->Primary().Count() == 1);
+        CHECK(num->Primary()[0] == expected_num);
+    }
+}
+
 TEST_CASE("SBigFromUnsigned", "[big]") {
     SECTION("creates bigdata from 0") {
         BigData* num;

--- a/test/Big.cpp
+++ b/test/Big.cpp
@@ -486,6 +486,26 @@ TEST_CASE("SBigIsOne", "[big]") {
     }
 }
 
+TEST_CASE("SBigIsZero", "[big]") {
+    BigDataTest a;
+
+    SECTION("unset is zero") {
+        CHECK(SBigIsZero(a));
+    }
+
+    SECTION("0 is 0") {
+        SBigFromUnsigned(a, 0);
+        CHECK(SBigIsZero(a));
+    }
+
+    SECTION("numbers are not 0") {
+        auto v = GENERATE(1ULL, 2ULL, 10ULL, 0xFFFFFFFFULL, 10000000000000ULL, 0xFF00000000000000ULL);
+
+        SBigFromStr(a, std::to_string(v).c_str());
+        CHECK_FALSE(SBigIsZero(a));
+    }
+}
+
 TEST_CASE("SBigMod", "[big]") {
     SECTION("mods 7 by 4") {
         BigData* a;

--- a/test/Big.cpp
+++ b/test/Big.cpp
@@ -470,6 +470,22 @@ TEST_CASE("SBigIsOdd", "[big]") {
     }
 }
 
+TEST_CASE("SBigIsOne", "[big]") {
+    BigDataTest a;
+
+    SECTION("1 is 1") {
+        SBigFromUnsigned(a, 1);
+        CHECK(SBigIsOne(a));
+    }
+
+    SECTION("numbers are not 1") {
+        auto v = GENERATE(0ULL, 2ULL, 10ULL, 11ULL, 10000000000001ULL, 0xFF00000000000001ULL);
+
+        SBigFromStr(a, std::to_string(v).c_str());
+        CHECK_FALSE(SBigIsOne(a));
+    }
+}
+
 TEST_CASE("SBigMod", "[big]") {
     SECTION("mods 7 by 4") {
         BigData* a;

--- a/test/Big.cpp
+++ b/test/Big.cpp
@@ -171,6 +171,7 @@ TEST_CASE("SBigDec", "[big]") {
         CHECK(a->Primary()[0] == 4);
     }
 
+#ifdef NDEBUG
     SECTION("decrements from 0") {
         SBigFromUnsigned(b, 0);
 
@@ -179,6 +180,7 @@ TEST_CASE("SBigDec", "[big]") {
         CHECK(a->Primary().Count() == 1);
         CHECK(a->Primary()[0] == 0xFFFFFFFF);
     }
+#endif
 }
 
 TEST_CASE("SBigDiv", "[big]") {
@@ -611,8 +613,8 @@ TEST_CASE("SBigOr", "[big]") {
         SBigOr(a, b, c);
 
         CHECK(a->Primary().Count() == 2);
-        CHECK(a->Primary()[0] == uint32_t(v.first | v.second));
-        CHECK(a->Primary()[1] == uint32_t((v.first | v.second) >> 32));
+        CHECK(a->Primary()[0] == 0xFFFFFFFF);
+        CHECK(a->Primary()[1] == 0xFFFFFFFF);
     }
 
     SECTION("performs bitwise or on huge value") {
@@ -694,6 +696,7 @@ TEST_CASE("SBigSub", "[big]") {
         CHECK(a->Primary()[0] == 1);
     }
 
+#ifdef NDEBUG
     SECTION("subtracts 1 from 0") {
         SBigFromUnsigned(b, 0);
         SBigFromUnsigned(c, 1);
@@ -703,6 +706,7 @@ TEST_CASE("SBigSub", "[big]") {
         CHECK(a->Primary().Count() == 1);
         CHECK(a->Primary()[0] == 0xFFFFFFFF);
     }
+#endif
 }
 
 TEST_CASE("SBigToBinaryBuffer", "[big]") {

--- a/test/Big.cpp
+++ b/test/Big.cpp
@@ -728,6 +728,47 @@ TEST_CASE("SBigPowMod", "[big]") {
     }
 }
 
+TEST_CASE("SBigNot", "[big]") {
+    BigDataTest a, b;
+
+    SECTION("bitwise negates small values") {
+        auto v = GENERATE(uint32_t(1), 2, 10, 0xFFFFFFFF);
+
+        SBigFromUnsigned(b, v);
+        SBigNot(a, b);
+
+        CHECK(a->Primary().Count() == 1);
+        CHECK(a->Primary()[0] == ~v);
+    }
+
+    SECTION("bitwise negates large values") {
+        auto v = GENERATE(10000000000000ULL, 0xFF00000000000000ULL);
+
+        SBigFromStr(b, std::to_string(v).c_str());
+        SBigNot(a, b);
+
+        CHECK(a->Primary().Count() == 2);
+        CHECK(a->Primary()[0] == ~uint32_t(v));
+        CHECK(a->Primary()[1] == ~uint32_t(v >> 32));
+    }
+
+    SECTION("bitwise negates huge value") {
+        uint32_t data[] = { 0xF00DFEED, 0xBA1D, 0xBEEBBEEB, 0x12345678, 0x9ABCDEF, 0xDEADCAD, 0xD011A };
+        
+        SBigFromBinary(b, data, sizeof(data));
+        SBigNot(a, b);
+
+        CHECK(a->Primary().Count() == 7);
+        CHECK(a->Primary()[0] == ~data[0]);
+        CHECK(a->Primary()[1] == ~data[1]);
+        CHECK(a->Primary()[2] == ~data[2]);
+        CHECK(a->Primary()[3] == ~data[3]);
+        CHECK(a->Primary()[4] == ~data[4]);
+        CHECK(a->Primary()[5] == ~data[5]);
+        CHECK(a->Primary()[6] == ~data[6]);
+    }
+}
+
 TEST_CASE("SBigShl", "[big]") {
     SECTION("shifts 256 left 7 bits") {
         BigData* a;

--- a/test/Big.cpp
+++ b/test/Big.cpp
@@ -92,6 +92,42 @@ TEST_CASE("SBigAdd", "[big]") {
     }
 }
 
+TEST_CASE("SBigAnd", "[big]") {
+    BigDataTest a;
+    BigDataTest b;
+    BigDataTest c;
+
+    SECTION("overwrites output") {
+        SBigFromUnsigned(a, 123456);
+        SBigFromUnsigned(b, 0);
+        SBigFromUnsigned(c, 0);
+
+        SBigAnd(a, b, c);
+
+        CHECK(a->Primary().Count() == 1);
+        CHECK(a->Primary()[0] == 0);
+    }
+
+    SECTION("performs bitwise and on large nums") {
+        uint8_t data[] = {
+            1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 31, 12, 13, 14, 15
+        };
+        uint8_t data2[] = {
+            0, 0, 0, 6, 6, 0, 6, 0, 0, 6, 0xFF, 6, 0, 6, 0
+        };
+        SBigFromBinary(b, data, sizeof(data));
+        SBigFromBinary(c, data2, sizeof(data2));
+
+        SBigAnd(a, b, c);
+
+        CHECK(a->Primary().Count() == 4);
+        CHECK(a->Primary()[0] == 0x04000000);
+        CHECK(a->Primary()[1] == 0x00060004);
+        CHECK(a->Primary()[2] == 0x041F0200);
+        CHECK(a->Primary()[3] == 0x00000600);
+    }
+}
+
 TEST_CASE("SBigBitLen", "[big]") {
     SECTION("returns bit length of 1") {
         BigData* num;

--- a/test/Big.cpp
+++ b/test/Big.cpp
@@ -448,6 +448,28 @@ TEST_CASE("SBigIsEven", "[big]") {
     }
 }
 
+TEST_CASE("SBigIsOdd", "[big]") {
+    BigDataTest a;
+
+    SECTION("unset zero is not odd") {
+        CHECK_FALSE(SBigIsOdd(a));
+    }
+
+    SECTION("numbers are not odd") {
+        auto v = GENERATE(0ULL, 2ULL, 10ULL, 10000ULL, 0xFFFFFFFEULL, 0x9999888877776666ULL);
+
+        SBigFromStr(a, std::to_string(v).c_str());
+        CHECK_FALSE(SBigIsOdd(a));
+    }
+
+    SECTION("numbers are odd") {
+        auto v = GENERATE(1ULL, 3ULL, 37ULL, 999999999ULL, 0xFFFFFFFFFULL, 0x9999888877776667ULL);
+
+        SBigFromStr(a, std::to_string(v).c_str());
+        CHECK(SBigIsOdd(a));
+    }
+}
+
 TEST_CASE("SBigMod", "[big]") {
     SECTION("mods 7 by 4") {
         BigData* a;

--- a/test/Big.cpp
+++ b/test/Big.cpp
@@ -330,6 +330,37 @@ TEST_CASE("SBigFromUnsigned", "[big]") {
         SBigDel(num);
     }
 }
+TEST_CASE("SBigInc", "[big]") {
+    BigDataTest a, b;
+
+    SECTION("increments from 0") {
+        SBigFromUnsigned(b, 0);
+
+        SBigInc(a, b);
+
+        CHECK(a->Primary().Count() == 1);
+        CHECK(a->Primary()[0] == 1);
+    }
+
+    SECTION("increments from max uint") {
+        SBigFromUnsigned(b, UINT32_MAX);
+
+        SBigInc(a, b);
+
+        CHECK(a->Primary().Count() == 2);
+        CHECK(a->Primary()[0] == 0);
+        CHECK(a->Primary()[1] == 1);
+    }
+
+    SECTION("increments from a number") {
+        SBigFromUnsigned(b, 1337);
+
+        SBigInc(a, b);
+
+        CHECK(a->Primary().Count() == 1);
+        CHECK(a->Primary()[0] == 1338);
+    }
+}
 
 TEST_CASE("SBigMod", "[big]") {
     SECTION("mods 7 by 4") {

--- a/test/Big.cpp
+++ b/test/Big.cpp
@@ -213,6 +213,24 @@ TEST_CASE("SBigCompare", "[big]") {
     }
 }
 
+TEST_CASE("SBigCopy", "[big]") {
+    BigDataTest a;
+    BigDataTest b;
+
+    SECTION("copies data") {
+        uint8_t num[] = { 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9 };
+        SBigFromBinary(a, num, sizeof(num));
+        SBigFromUnsigned(b, 42);
+
+        CHECK(a->Primary().Count() == 4);
+
+        SBigCopy(a, b);
+
+        CHECK(a->Primary().Count() == 1);
+        CHECK(a->Primary()[0] == 42);
+    }
+}
+
 TEST_CASE("SBigFromBinary", "[big]") {
     SECTION("creates bigdata from 0") {
         BigData* num;

--- a/test/Big.cpp
+++ b/test/Big.cpp
@@ -746,6 +746,30 @@ TEST_CASE("SBigToBinaryBuffer", "[big]") {
     }
 }
 
+TEST_CASE("SBigToUnsigned", "[big]") {
+    BigDataTest num;
+
+    SECTION("converts bignum values to uint") {
+        auto v = GENERATE(0UL, 1UL, 1000UL, UINT32_MAX);
+
+        SBigFromUnsigned(num, v);
+
+        uint32_t result;
+        SBigToUnsigned(num, &result);
+
+        CHECK(result == v);
+    }
+
+    SECTION("truncates large values") {
+        SBigFromStr(num, std::to_string(0x123456789ABCDEFULL).c_str());
+
+        uint32_t result;
+        SBigToUnsigned(num, &result);
+
+        CHECK(result == 0x89ABCDEF);
+    }
+}
+
 TEST_CASE("SBigXor", "[big]") {
     BigDataTest a, b, c;
 

--- a/test/Test.cpp
+++ b/test/Test.cpp
@@ -1,2 +1,8 @@
 #define CATCH_CONFIG_MAIN
 #include "test/Test.hpp"
+#include "storm/Big.hpp"
+
+
+BigDataTest::BigDataTest() { SBigNew(&num); }
+BigDataTest::~BigDataTest() { SBigDel(num); }
+

--- a/test/Test.hpp
+++ b/test/Test.hpp
@@ -1,1 +1,17 @@
 #include "vendor/catch-2.13.10/catch.hpp"
+
+class BigData;
+
+// Fixture for repetitive handling of BigData objects.
+struct BigDataTest {
+    using BigDataPtr=BigData*;
+
+    BigData *num;
+
+    BigDataTest();
+    ~BigDataTest();
+
+    BigData **operator &() { return &num; }
+    operator BigDataPtr() const { return num; }
+    BigData *operator->() const { return num; }
+};

--- a/test/Test.hpp
+++ b/test/Test.hpp
@@ -4,14 +4,14 @@ class BigData;
 
 // Fixture for repetitive handling of BigData objects.
 struct BigDataTest {
-    using BigDataPtr=BigData*;
+    using BigDataPtr = BigData*;
 
-    BigData *num;
+    BigData* num;
 
     BigDataTest();
     ~BigDataTest();
 
-    BigData **operator &() { return &num; }
+    BigData** operator &() { return &num; }
     operator BigDataPtr() const { return num; }
-    BigData *operator->() const { return num; }
+    BigData* operator->() const { return num; }
 };

--- a/test/big/Ops.cpp
+++ b/test/big/Ops.cpp
@@ -970,6 +970,7 @@ TEST_CASE("Sub", "[big]") {
         CHECK(a->Primary()[0] == 1);
     }
 
+#ifdef NDEBUG
     SECTION("subtracts 1 from 0") {
         SBigFromUnsigned(b, 0);
         SBigFromUnsigned(c, 1);
@@ -988,6 +989,7 @@ TEST_CASE("Sub", "[big]") {
         CHECK(a->Primary().Count() == 1);
         CHECK(a->Primary()[0] == 0xFFFFFFFF);
     }
+#endif
 
     SECTION("subtracts 1 from 2") {
         SBigFromUnsigned(b, 2);

--- a/test/big/Ops.cpp
+++ b/test/big/Ops.cpp
@@ -3,15 +3,12 @@
 #include "test/Test.hpp"
 
 TEST_CASE("Add", "[big]") {
-    SECTION("adds 0 and 1") {
-        BigData* a;
-        SBigNew(&a);
+    BigDataTest a, b;
 
-        BigData* b;
-        SBigNew(&b);
+    SECTION("adds 0 and 1") {
         SBigFromUnsigned(b, 0);
 
-        uint64_t c = 1;
+        uint32_t c = 1;
 
         Add(a->Primary(), b->Primary(), c);
 
@@ -19,20 +16,12 @@ TEST_CASE("Add", "[big]") {
 
         CHECK(a->Primary().Count() == 1);
         CHECK(a->Primary()[0] == 1);
-
-        SBigDel(a);
-        SBigDel(b);
     }
 
     SECTION("adds 2 and 4") {
-        BigData* a;
-        SBigNew(&a);
-
-        BigData* b;
-        SBigNew(&b);
         SBigFromUnsigned(b, 2);
 
-        uint64_t c = 4;
+        uint32_t c = 4;
 
         Add(a->Primary(), b->Primary(), c);
 
@@ -40,20 +29,12 @@ TEST_CASE("Add", "[big]") {
 
         CHECK(a->Primary().Count() == 1);
         CHECK(a->Primary()[0] == 6);
-
-        SBigDel(a);
-        SBigDel(b);
     }
 
     SECTION("adds 0xFFFFFFFF and 0xCCCCCCCC") {
-        BigData* a;
-        SBigNew(&a);
-
-        BigData* b;
-        SBigNew(&b);
         SBigFromUnsigned(b, 0xFFFFFFFF);
 
-        uint64_t c = 0xCCCCCCCC;
+        uint32_t c = 0xCCCCCCCC;
 
         Add(a->Primary(), b->Primary(), c);
 
@@ -62,16 +43,11 @@ TEST_CASE("Add", "[big]") {
         CHECK(a->Primary().Count() == 2);
         CHECK(a->Primary()[0] == 0xCCCCCCCB);
         CHECK(a->Primary()[1] == 0x1);
-
-        SBigDel(a);
-        SBigDel(b);
     }
 }
 
 TEST_CASE("And", "[big]") {
-    BigDataTest a;
-    BigDataTest b;
-    BigDataTest c;
+    BigDataTest a, b, c;
 
     SECTION("overwrites output") {
         SBigFromUnsigned(a, 123456);
@@ -105,93 +81,51 @@ TEST_CASE("And", "[big]") {
 }
 
 TEST_CASE("Compare", "[big]") {
-    SECTION("compares 0 and 1") {
-        BigData* a;
-        SBigNew(&a);
-        SBigFromUnsigned(a, 0);
+    BigDataTest a, b;
 
-        BigData* b;
-        SBigNew(&b);
+    SECTION("compares 0 and 1") {
+        SBigFromUnsigned(a, 0);
         SBigFromUnsigned(b, 1);
 
         CHECK(Compare(a->Primary(), b->Primary()) == -1);
-
-        SBigDel(a);
-        SBigDel(b);
     }
 
     SECTION("compares 1 and 1") {
-        BigData* a;
-        SBigNew(&a);
         SBigFromUnsigned(a, 1);
-
-        BigData* b;
-        SBigNew(&b);
         SBigFromUnsigned(b, 1);
 
         CHECK(Compare(a->Primary(), b->Primary()) == 0);
-
-        SBigDel(a);
-        SBigDel(b);
     }
 
     SECTION("compares 10 and 1") {
-        BigData* a;
-        SBigNew(&a);
         SBigFromUnsigned(a, 10);
-
-        BigData* b;
-        SBigNew(&b);
         SBigFromUnsigned(b, 1);
 
         CHECK(Compare(a->Primary(), b->Primary()) == 1);
-
-        SBigDel(a);
-        SBigDel(b);
     }
 
     SECTION("compares 0x1111111111111111 and 0x22222222") {
-        BigData* a;
-        SBigNew(&a);
         uint64_t data = 0x1111111111111111;
         SBigFromBinary(a, reinterpret_cast<uint8_t*>(&data), sizeof(data));
-
-        BigData* b;
-        SBigNew(&b);
         SBigFromUnsigned(b, 0x22222222);
 
         CHECK(Compare(a->Primary(), b->Primary()) == 1);
-
-        SBigDel(a);
-        SBigDel(b);
     }
 
     SECTION("compares 0x11111111 and 0x2222222222222222") {
-        BigData* a;
-        SBigNew(&a);
         SBigFromUnsigned(a, 0x11111111);
-
-        BigData* b;
-        SBigNew(&b);
+        
         uint64_t data = 0x2222222222222222;
         SBigFromBinary(b, reinterpret_cast<uint8_t*>(&data), sizeof(data));
 
         CHECK(Compare(a->Primary(), b->Primary()) == -1);
-
-        SBigDel(a);
-        SBigDel(b);
     }
 }
 
 TEST_CASE("Div", "[big]") {
+    BigDataTest a, b, c, d;
     SECTION("divides 2 by 1") {
-        BigData* a;
-        SBigNew(&a);
-
         uint32_t b;
-
-        BigData* c;
-        SBigNew(&c);
         SBigFromUnsigned(c, 2);
 
         uint64_t d = 1;
@@ -201,24 +135,10 @@ TEST_CASE("Div", "[big]") {
         CHECK(a->Primary().Count() == 1);
         CHECK(a->Primary()[0] == 2);
         CHECK(b == 0);
-
-        SBigDel(a);
-        SBigDel(c);
     }
 
     SECTION("divides 2 by 1 (buffer divisor)") {
-        BigData* a;
-        SBigNew(&a);
-
-        BigData* b;
-        SBigNew(&b);
-
-        BigData* c;
-        SBigNew(&c);
         SBigFromUnsigned(c, 2);
-
-        BigData* d;
-        SBigNew(&d);
         SBigFromUnsigned(d, 1);
 
         Div(a->Primary(), b->Primary(), c->Primary(), d->Primary(), a->Stack());
@@ -229,21 +149,11 @@ TEST_CASE("Div", "[big]") {
         CHECK(a->Primary().Count() == 1);
         CHECK(a->Primary()[0] == 2);
         CHECK(b->Primary().Count() == 0);
-
-        SBigDel(a);
-        SBigDel(b);
-        SBigDel(c);
-        SBigDel(d);
     }
 
     SECTION("divides 5 by 2") {
-        BigData* a;
-        SBigNew(&a);
-
         uint32_t b;
 
-        BigData* c;
-        SBigNew(&c);
         SBigFromUnsigned(c, 5);
 
         uint64_t d = 2;
@@ -253,19 +163,11 @@ TEST_CASE("Div", "[big]") {
         CHECK(a->Primary().Count() == 1);
         CHECK(a->Primary()[0] == 2);
         CHECK(b == 1);
-
-        SBigDel(a);
-        SBigDel(c);
     }
 
     SECTION("divides 7 by 4") {
-        BigData* a;
-        SBigNew(&a);
-
         uint32_t b;
 
-        BigData* c;
-        SBigNew(&c);
         SBigFromUnsigned(c, 7);
 
         uint64_t d = 4;
@@ -275,24 +177,10 @@ TEST_CASE("Div", "[big]") {
         CHECK(a->Primary().Count() == 1);
         CHECK(a->Primary()[0] == 1);
         CHECK(b == 3);
-
-        SBigDel(a);
-        SBigDel(c);
     }
 
     SECTION("divides 7 by 4 (buffer divisor)") {
-        BigData* a;
-        SBigNew(&a);
-
-        BigData* b;
-        SBigNew(&b);
-
-        BigData* c;
-        SBigNew(&c);
         SBigFromUnsigned(c, 7);
-
-        BigData* d;
-        SBigNew(&d);
         SBigFromUnsigned(d, 4);
 
         Div(a->Primary(), b->Primary(), c->Primary(), d->Primary(), a->Stack());
@@ -304,21 +192,11 @@ TEST_CASE("Div", "[big]") {
         CHECK(a->Primary()[0] == 1);
         CHECK(b->Primary().Count() == 1);
         CHECK(b->Primary()[0] == 3);
-
-        SBigDel(a);
-        SBigDel(b);
-        SBigDel(c);
-        SBigDel(d);
     }
 
     SECTION("divides 0x9999444488885555 by 0x2222") {
-        BigData* a;
-        SBigNew(&a);
-
         uint32_t b;
 
-        BigData* c;
-        SBigNew(&c);
         uint64_t c_ = 0x9999444488885555;
         SBigFromBinary(c, reinterpret_cast<uint8_t*>(&c_), sizeof(c_));
 
@@ -330,25 +208,12 @@ TEST_CASE("Div", "[big]") {
         CHECK(a->Primary()[0] == 0x00040002);
         CHECK(a->Primary()[1] == 0x48002);
         CHECK(b == 0x1111);
-
-        SBigDel(a);
-        SBigDel(c);
     }
 
     SECTION("divides 0x9999444488885555 by 0x2222 (buffer divisor)") {
-        BigData* a;
-        SBigNew(&a);
-
-        BigData* b;
-        SBigNew(&b);
-
-        BigData* c;
-        SBigNew(&c);
         uint64_t c_ = 0x9999444488885555;
         SBigFromBinary(c, reinterpret_cast<uint8_t*>(&c_), sizeof(c_));
 
-        BigData* d;
-        SBigNew(&d);
         SBigFromUnsigned(d, 0x2222);
 
         Div(a->Primary(), b->Primary(), c->Primary(), d->Primary(), a->Stack());
@@ -361,21 +226,11 @@ TEST_CASE("Div", "[big]") {
         CHECK(a->Primary()[1] == 0x48002);
         CHECK(b->Primary().Count() == 1);
         CHECK(b->Primary()[0] == 0x1111);
-
-        SBigDel(a);
-        SBigDel(b);
-        SBigDel(c);
-        SBigDel(d);
     }
 
     SECTION("divides 0x9999444488885555 by 0xFFFFFFFF") {
-        BigData* a;
-        SBigNew(&a);
-
         uint32_t b;
 
-        BigData* c;
-        SBigNew(&c);
         uint64_t c_ = 0x9999444488885555;
         SBigFromBinary(c, reinterpret_cast<uint8_t*>(&c_), sizeof(c_));
 
@@ -386,25 +241,12 @@ TEST_CASE("Div", "[big]") {
         CHECK(a->Primary().Count() == 1);
         CHECK(a->Primary()[0] == 0x99994445);
         CHECK(b == 0x2221999A);
-
-        SBigDel(a);
-        SBigDel(c);
     }
 
     SECTION("divides 0x9999444488885555 by 0xFFFFFFFF (buffer divisor)") {
-        BigData* a;
-        SBigNew(&a);
-
-        BigData* b;
-        SBigNew(&b);
-
-        BigData* c;
-        SBigNew(&c);
         uint64_t c_ = 0x9999444488885555;
         SBigFromBinary(c, reinterpret_cast<uint8_t*>(&c_), sizeof(c_));
 
-        BigData* d;
-        SBigNew(&d);
         SBigFromUnsigned(d, 0xFFFFFFFF);
 
         Div(a->Primary(), b->Primary(), c->Primary(), d->Primary(), a->Stack());
@@ -416,27 +258,12 @@ TEST_CASE("Div", "[big]") {
         CHECK(a->Primary()[0] == 0x99994445);
         CHECK(b->Primary().Count() == 1);
         CHECK(b->Primary()[0] == 0x2221999A);
-
-        SBigDel(a);
-        SBigDel(b);
-        SBigDel(c);
-        SBigDel(d);
     }
 
     SECTION("divides 0x9999444488885555 by 0x1111222233334444 (buffer divisor)") {
-        BigData* a;
-        SBigNew(&a);
-
-        BigData* b;
-        SBigNew(&b);
-
-        BigData* c;
-        SBigNew(&c);
         uint64_t c_ = 0x9999444488885555;
         SBigFromBinary(c, reinterpret_cast<uint8_t*>(&c_), sizeof(c_));
 
-        BigData* d;
-        SBigNew(&d);
         uint64_t d_ = 0x1111222233334444;
         SBigFromBinary(d, reinterpret_cast<uint8_t*>(&d_), sizeof(d_));
 
@@ -450,11 +277,6 @@ TEST_CASE("Div", "[big]") {
         CHECK(b->Primary().Count() == 2);
         CHECK(b->Primary()[0] == 0xEEEE3335);
         CHECK(b->Primary()[1] == 0x11103332);
-
-        SBigDel(a);
-        SBigDel(b);
-        SBigDel(c);
-        SBigDel(d);
     }
 }
 
@@ -582,65 +404,42 @@ TEST_CASE("ExtractLowPartSx", "[big]") {
 }
 
 TEST_CASE("HighBitPos", "[big]") {
+    BigDataTest num;
     SECTION("returns position of high bit for 0") {
-        BigData* num;
-        SBigNew(&num);
         SBigFromUnsigned(num, 0);
 
         CHECK(HighBitPos(num->Primary()) == 0);
-
-        SBigDel(num);
     }
 
     SECTION("returns position of high bit for 0x1000") {
-        BigData* num;
-        SBigNew(&num);
         SBigFromUnsigned(num, 0x1000);
 
         CHECK(HighBitPos(num->Primary()) == 12);
-
-        SBigDel(num);
     }
 
     SECTION("returns position of high bit for 0x1111") {
-        BigData* num;
-        SBigNew(&num);
         SBigFromUnsigned(num, 0x1111);
 
         CHECK(HighBitPos(num->Primary()) == 12);
-
-        SBigDel(num);
     }
 
     SECTION("returns position of high bit for 0xFFFF") {
-        BigData* num;
-        SBigNew(&num);
         SBigFromUnsigned(num, 0xFFFF);
 
         CHECK(HighBitPos(num->Primary()) == 15);
-
-        SBigDel(num);
     }
 
     SECTION("returns position of high bit for 0xFFFFFFFF") {
-        BigData* num;
-        SBigNew(&num);
         SBigFromUnsigned(num, 0xFFFFFFFF);
 
         CHECK(HighBitPos(num->Primary()) == 31);
-
-        SBigDel(num);
     }
 
     SECTION("returns position of high bit for 0x123456789ABCDEF0") {
-        BigData* num;
-        SBigNew(&num);
         uint64_t data = 0x123456789ABCDEF0;
         SBigFromBinary(num, reinterpret_cast<uint8_t*>(&data), sizeof(data));
 
         CHECK(HighBitPos(num->Primary()) == 60);
-
-        SBigDel(num);
     }
 }
 
@@ -671,12 +470,9 @@ TEST_CASE("InsertLowPart", "[big]") {
 }
 
 TEST_CASE("Mul", "[big]") {
-    SECTION("multiplies 0 and 1") {
-        BigData* a;
-        SBigNew(&a);
+    BigDataTest a, b;
 
-        BigData* b;
-        SBigNew(&b);
+    SECTION("multiplies 0 and 1") {
         SBigFromUnsigned(b, 0);
 
         uint64_t c = 1;
@@ -686,17 +482,9 @@ TEST_CASE("Mul", "[big]") {
         a->Primary().Trim();
 
         CHECK(a->Primary().Count() == 0);
-
-        SBigDel(a);
-        SBigDel(b);
     }
 
     SECTION("multiplies 2 and 4") {
-        BigData* a;
-        SBigNew(&a);
-
-        BigData* b;
-        SBigNew(&b);
         SBigFromUnsigned(b, 2);
 
         uint64_t c = 4;
@@ -707,17 +495,9 @@ TEST_CASE("Mul", "[big]") {
 
         CHECK(a->Primary().Count() == 1);
         CHECK(a->Primary()[0] == 8);
-
-        SBigDel(a);
-        SBigDel(b);
     }
 
     SECTION("multiplies 0xFFFFFFFF and 0x100") {
-        BigData* a;
-        SBigNew(&a);
-
-        BigData* b;
-        SBigNew(&b);
         SBigFromUnsigned(b, 0xFFFFFFFF);
 
         uint64_t c = 0x100;
@@ -729,27 +509,15 @@ TEST_CASE("Mul", "[big]") {
         CHECK(a->Primary().Count() == 2);
         CHECK(a->Primary()[0] == 0xFFFFFF00);
         CHECK(a->Primary()[1] == 0xFF);
-
-        SBigDel(a);
-        SBigDel(b);
     }
 }
 
 TEST_CASE("MulMod", "[big]") {
+    BigDataTest a, b, c, d;
+
     SECTION("multiplies 0xFFFFFFFF by 0x100 and mods the result by 0xABC") {
-        BigData* a;
-        SBigNew(&a);
-
-        BigData* b;
-        SBigNew(&b);
         SBigFromUnsigned(b, 0xFFFFFFFF);
-
-        BigData* c;
-        SBigNew(&c);
         SBigFromUnsigned(c, 0x100);
-
-        BigData* d;
-        SBigNew(&d);
         SBigFromUnsigned(d, 0xABC);
 
         MulMod(a->Primary(), b->Primary(), c->Primary(), d->Primary(), a->Stack());
@@ -758,29 +526,15 @@ TEST_CASE("MulMod", "[big]") {
 
         CHECK(a->Primary().Count() == 1);
         CHECK(a->Primary()[0] == 0x624);
-
-        SBigDel(a);
-        SBigDel(b);
-        SBigDel(c);
-        SBigDel(d);
     }
 
     SECTION("multiplies 0x123456789ABCDEF0 by 0xFEDCBA9876543210 and mods the result by 0x10000000") {
-        BigData* a;
-        SBigNew(&a);
-
-        BigData* b;
-        SBigNew(&b);
         uint64_t b_ = 0x123456789ABCDEF0;
         SBigFromBinary(b, reinterpret_cast<uint8_t*>(&b_), sizeof(b_));
 
-        BigData* c;
-        SBigNew(&c);
         uint64_t c_ = 0xFEDCBA9876543210;
         SBigFromBinary(c, reinterpret_cast<uint8_t*>(&c_), sizeof(c_));
 
-        BigData* d;
-        SBigNew(&d);
         SBigFromUnsigned(d, 0x10000000);
 
         MulMod(a->Primary(), b->Primary(), c->Primary(), d->Primary(), a->Stack());
@@ -789,11 +543,6 @@ TEST_CASE("MulMod", "[big]") {
 
         CHECK(a->Primary().Count() == 1);
         CHECK(a->Primary()[0] == 0x618CF00);
-
-        SBigDel(a);
-        SBigDel(b);
-        SBigDel(c);
-        SBigDel(d);
     }
 }
 
@@ -812,20 +561,11 @@ TEST_CASE("MakeLarge", "[big]") {
 }
 
 TEST_CASE("PowMod", "[big]") {
+    BigDataTest a, b, c, d;
+
     SECTION("takes 0 to the 0th power and mods the result by 1") {
-        BigData* a;
-        SBigNew(&a);
-
-        BigData* b;
-        SBigNew(&b);
         SBigFromUnsigned(b, 0);
-
-        BigData* c;
-        SBigNew(&c);
         SBigFromUnsigned(c, 0);
-
-        BigData* d;
-        SBigNew(&d);
         SBigFromUnsigned(d, 1);
 
         PowMod(a->Primary(), b->Primary(), c->Primary(), d->Primary(), a->Stack());
@@ -834,27 +574,11 @@ TEST_CASE("PowMod", "[big]") {
 
         CHECK(a->Primary().Count() == 1);
         CHECK(a->Primary()[0] == 1);
-
-        SBigDel(a);
-        SBigDel(b);
-        SBigDel(c);
-        SBigDel(d);
     }
 
     SECTION("takes 2 to the 0th power and mods the result by 7") {
-        BigData* a;
-        SBigNew(&a);
-
-        BigData* b;
-        SBigNew(&b);
         SBigFromUnsigned(b, 2);
-
-        BigData* c;
-        SBigNew(&c);
         SBigFromUnsigned(c, 0);
-
-        BigData* d;
-        SBigNew(&d);
         SBigFromUnsigned(d, 7);
 
         PowMod(a->Primary(), b->Primary(), c->Primary(), d->Primary(), a->Stack());
@@ -863,27 +587,11 @@ TEST_CASE("PowMod", "[big]") {
 
         CHECK(a->Primary().Count() == 1);
         CHECK(a->Primary()[0] == 1);
-
-        SBigDel(a);
-        SBigDel(b);
-        SBigDel(c);
-        SBigDel(d);
     }
 
     SECTION("takes 2 to the 4th power and mods the result by 7") {
-        BigData* a;
-        SBigNew(&a);
-
-        BigData* b;
-        SBigNew(&b);
         SBigFromUnsigned(b, 2);
-
-        BigData* c;
-        SBigNew(&c);
         SBigFromUnsigned(c, 4);
-
-        BigData* d;
-        SBigNew(&d);
         SBigFromUnsigned(d, 7);
 
         PowMod(a->Primary(), b->Primary(), c->Primary(), d->Primary(), a->Stack());
@@ -892,27 +600,11 @@ TEST_CASE("PowMod", "[big]") {
 
         CHECK(a->Primary().Count() == 1);
         CHECK(a->Primary()[0] == 2);
-
-        SBigDel(a);
-        SBigDel(b);
-        SBigDel(c);
-        SBigDel(d);
     }
 
     SECTION("takes 256 to the 8th power and mods the result by 999") {
-        BigData* a;
-        SBigNew(&a);
-
-        BigData* b;
-        SBigNew(&b);
         SBigFromUnsigned(b, 256);
-
-        BigData* c;
-        SBigNew(&c);
         SBigFromUnsigned(c, 8);
-
-        BigData* d;
-        SBigNew(&d);
         SBigFromUnsigned(d, 999);
 
         PowMod(a->Primary(), b->Primary(), c->Primary(), d->Primary(), a->Stack());
@@ -921,28 +613,13 @@ TEST_CASE("PowMod", "[big]") {
 
         CHECK(a->Primary().Count() == 1);
         CHECK(a->Primary()[0] == 160);
-
-        SBigDel(a);
-        SBigDel(b);
-        SBigDel(c);
-        SBigDel(d);
     }
 
     SECTION("takes 0x100000000 to the 2nd power and mods the result by 0xAAAAFFFF") {
-        BigData* a;
-        SBigNew(&a);
-
-        BigData* b;
-        SBigNew(&b);
         uint64_t b_ = 0x100000000;
         SBigFromBinary(b, reinterpret_cast<uint8_t*>(&b_), sizeof(b_));
 
-        BigData* c;
-        SBigNew(&c);
         SBigFromUnsigned(c, 2);
-
-        BigData* d;
-        SBigNew(&d);
         SBigFromUnsigned(d, 0xAAAAFFFF);
 
         PowMod(a->Primary(), b->Primary(), c->Primary(), d->Primary(), a->Stack());
@@ -951,28 +628,14 @@ TEST_CASE("PowMod", "[big]") {
 
         CHECK(a->Primary().Count() == 1);
         CHECK(a->Primary()[0] == 0x6AA94002);
-
-        SBigDel(a);
-        SBigDel(b);
-        SBigDel(c);
-        SBigDel(d);
     }
 
     SECTION("takes 0xABCDEF1234567890 to the 16th power and mods the result by 0xEEEE000000000001") {
-        BigData* a;
-        SBigNew(&a);
-
-        BigData* b;
-        SBigNew(&b);
         uint64_t b_ = 0xABCDEF1234567890;
         SBigFromBinary(b, reinterpret_cast<uint8_t*>(&b_), sizeof(b_));
 
-        BigData* c;
-        SBigNew(&c);
         SBigFromUnsigned(c, 16);
 
-        BigData* d;
-        SBigNew(&d);
         uint64_t d_ = 0xEEEE000000000001;
         SBigFromBinary(d, reinterpret_cast<uint8_t*>(&d_), sizeof(d_));
 
@@ -983,18 +646,13 @@ TEST_CASE("PowMod", "[big]") {
         CHECK(a->Primary().Count() == 2);
         CHECK(a->Primary()[0] == 0x950A5465);
         CHECK(a->Primary()[1] == 0xA0CB742F);
-
-        SBigDel(a);
-        SBigDel(b);
-        SBigDel(c);
-        SBigDel(d);
     }
 }
 
 TEST_CASE("SetOne", "[big]") {
+    BigDataTest num;
+
     SECTION("sets buffer to one") {
-        BigData* num;
-        SBigNew(&num);
         uint64_t data = 0x123456789ABCDEF0;
         SBigFromBinary(num, reinterpret_cast<uint8_t*>(&data), sizeof(data));
 
@@ -1004,15 +662,13 @@ TEST_CASE("SetOne", "[big]") {
 
         CHECK(num->Primary().Count() == 1);
         CHECK(num->Primary()[0] == 1);
-
-        SBigDel(num);
     }
 }
 
 TEST_CASE("SetZero", "[big]") {
+    BigDataTest num;
+    
     SECTION("sets buffer to zero") {
-        BigData* num;
-        SBigNew(&num);
         SBigFromUnsigned(num, 0x12345678);
 
         CHECK(num->Primary().Count() == 1);
@@ -1020,18 +676,13 @@ TEST_CASE("SetZero", "[big]") {
         SetZero(num->Primary());
 
         CHECK(num->Primary().Count() == 0);
-
-        SBigDel(num);
     }
 }
 
 TEST_CASE("Shl", "[big]") {
-    SECTION("shifts 0 left 1 bit") {
-        BigData* a;
-        SBigNew(&a);
+    BigDataTest a, b;
 
-        BigData* b;
-        SBigNew(&b);
+    SECTION("shifts 0 left 1 bit") {
         SBigFromUnsigned(b, 0);
 
         Shl(a->Primary(), b->Primary(), 1);
@@ -1039,17 +690,9 @@ TEST_CASE("Shl", "[big]") {
         a->Primary().Trim();
 
         CHECK(a->Primary().Count() == 0);
-
-        SBigDel(a);
-        SBigDel(b);
     }
 
     SECTION("shifts 1 left 0 bits") {
-        BigData* a;
-        SBigNew(&a);
-
-        BigData* b;
-        SBigNew(&b);
         SBigFromUnsigned(b, 1);
 
         Shl(a->Primary(), b->Primary(), 0);
@@ -1058,17 +701,9 @@ TEST_CASE("Shl", "[big]") {
 
         CHECK(a->Primary().Count() == 1);
         CHECK(a->Primary()[0] == 1);
-
-        SBigDel(a);
-        SBigDel(b);
     }
 
     SECTION("shifts 1 left 1 bit") {
-        BigData* a;
-        SBigNew(&a);
-
-        BigData* b;
-        SBigNew(&b);
         SBigFromUnsigned(b, 1);
 
         Shl(a->Primary(), b->Primary(), 1);
@@ -1077,17 +712,9 @@ TEST_CASE("Shl", "[big]") {
 
         CHECK(a->Primary().Count() == 1);
         CHECK(a->Primary()[0] == 2);
-
-        SBigDel(a);
-        SBigDel(b);
     }
 
     SECTION("shifts 2 left 1 bit") {
-        BigData* a;
-        SBigNew(&a);
-
-        BigData* b;
-        SBigNew(&b);
         SBigFromUnsigned(b, 2);
 
         Shl(a->Primary(), b->Primary(), 1);
@@ -1096,17 +723,9 @@ TEST_CASE("Shl", "[big]") {
 
         CHECK(a->Primary().Count() == 1);
         CHECK(a->Primary()[0] == 4);
-
-        SBigDel(a);
-        SBigDel(b);
     }
 
     SECTION("shifts 256 left 7 bits") {
-        BigData* a;
-        SBigNew(&a);
-
-        BigData* b;
-        SBigNew(&b);
         SBigFromUnsigned(b, 256);
 
         Shl(a->Primary(), b->Primary(), 7);
@@ -1115,17 +734,9 @@ TEST_CASE("Shl", "[big]") {
 
         CHECK(a->Primary().Count() == 1);
         CHECK(a->Primary()[0] == 32768);
-
-        SBigDel(a);
-        SBigDel(b);
     }
 
     SECTION("shifts 0xFFFFFFFF left 10 bits") {
-        BigData* a;
-        SBigNew(&a);
-
-        BigData* b;
-        SBigNew(&b);
         uint64_t b_ = 0xFFFFFFFF;
         SBigFromBinary(b, reinterpret_cast<uint8_t*>(&b_), sizeof(b_));
 
@@ -1136,17 +747,9 @@ TEST_CASE("Shl", "[big]") {
         CHECK(a->Primary().Count() == 2);
         CHECK(a->Primary()[0] == 0xFFFFFC00);
         CHECK(a->Primary()[1] == 0x3FF);
-
-        SBigDel(a);
-        SBigDel(b);
     }
 
     SECTION("shifts 0x1000000000000000 left 1 bit") {
-        BigData* a;
-        SBigNew(&a);
-
-        BigData* b;
-        SBigNew(&b);
         uint64_t b_ = 0x1000000000000000;
         SBigFromBinary(b, reinterpret_cast<uint8_t*>(&b_), sizeof(b_));
 
@@ -1157,17 +760,9 @@ TEST_CASE("Shl", "[big]") {
         CHECK(a->Primary().Count() == 2);
         CHECK(a->Primary()[0] == 0);
         CHECK(a->Primary()[1] == 0x20000000);
-
-        SBigDel(a);
-        SBigDel(b);
     }
 
     SECTION("shifts 0x1000000000000000 left 16 bits") {
-        BigData* a;
-        SBigNew(&a);
-
-        BigData* b;
-        SBigNew(&b);
         uint64_t b_ = 0x1000000000000000;
         SBigFromBinary(b, reinterpret_cast<uint8_t*>(&b_), sizeof(b_));
 
@@ -1179,19 +774,13 @@ TEST_CASE("Shl", "[big]") {
         CHECK(a->Primary()[0] == 0);
         CHECK(a->Primary()[1] == 0);
         CHECK(a->Primary()[2] == 0x1000);
-
-        SBigDel(a);
-        SBigDel(b);
     }
 }
 
 TEST_CASE("Shr", "[big]") {
-    SECTION("shifts 0 right 1 bit") {
-        BigData* a;
-        SBigNew(&a);
+    BigDataTest a, b;
 
-        BigData* b;
-        SBigNew(&b);
+    SECTION("shifts 0 right 1 bit") {
         SBigFromUnsigned(b, 0);
 
         Shr(a->Primary(), b->Primary(), 1);
@@ -1199,17 +788,9 @@ TEST_CASE("Shr", "[big]") {
         a->Primary().Trim();
 
         CHECK(a->Primary().Count() == 0);
-
-        SBigDel(a);
-        SBigDel(b);
     }
 
     SECTION("shifts 1 right 0 bits") {
-        BigData* a;
-        SBigNew(&a);
-
-        BigData* b;
-        SBigNew(&b);
         SBigFromUnsigned(b, 1);
 
         Shr(a->Primary(), b->Primary(), 0);
@@ -1218,17 +799,9 @@ TEST_CASE("Shr", "[big]") {
 
         CHECK(a->Primary().Count() == 1);
         CHECK(a->Primary()[0] == 1);
-
-        SBigDel(a);
-        SBigDel(b);
     }
 
     SECTION("shifts 1 right 1 bit") {
-        BigData* a;
-        SBigNew(&a);
-
-        BigData* b;
-        SBigNew(&b);
         SBigFromUnsigned(b, 1);
 
         Shr(a->Primary(), b->Primary(), 1);
@@ -1236,17 +809,9 @@ TEST_CASE("Shr", "[big]") {
         a->Primary().Trim();
 
         CHECK(a->Primary().Count() == 0);
-
-        SBigDel(a);
-        SBigDel(b);
     }
 
     SECTION("shifts 2 right 1 bit") {
-        BigData* a;
-        SBigNew(&a);
-
-        BigData* b;
-        SBigNew(&b);
         SBigFromUnsigned(b, 2);
 
         Shr(a->Primary(), b->Primary(), 1);
@@ -1255,17 +820,9 @@ TEST_CASE("Shr", "[big]") {
 
         CHECK(a->Primary().Count() == 1);
         CHECK(a->Primary()[0] == 1);
-
-        SBigDel(a);
-        SBigDel(b);
     }
 
     SECTION("shifts 2 right 1 bit") {
-        BigData* a;
-        SBigNew(&a);
-
-        BigData* b;
-        SBigNew(&b);
         SBigFromUnsigned(b, 2);
 
         Shr(a->Primary(), b->Primary(), 1);
@@ -1274,17 +831,9 @@ TEST_CASE("Shr", "[big]") {
 
         CHECK(a->Primary().Count() == 1);
         CHECK(a->Primary()[0] == 1);
-
-        SBigDel(a);
-        SBigDel(b);
     }
 
     SECTION("shifts 256 right 7 bits") {
-        BigData* a;
-        SBigNew(&a);
-
-        BigData* b;
-        SBigNew(&b);
         SBigFromUnsigned(b, 256);
 
         Shr(a->Primary(), b->Primary(), 7);
@@ -1293,17 +842,9 @@ TEST_CASE("Shr", "[big]") {
 
         CHECK(a->Primary().Count() == 1);
         CHECK(a->Primary()[0] == 2);
-
-        SBigDel(a);
-        SBigDel(b);
     }
 
     SECTION("shifts 0x1000000000000000 right 2 bits") {
-        BigData* a;
-        SBigNew(&a);
-
-        BigData* b;
-        SBigNew(&b);
         uint64_t b_ = 0x1000000000000000;
         SBigFromBinary(b, reinterpret_cast<uint8_t*>(&b_), sizeof(b_));
 
@@ -1314,17 +855,9 @@ TEST_CASE("Shr", "[big]") {
         CHECK(a->Primary().Count() == 2);
         CHECK(a->Primary()[0] == 0);
         CHECK(a->Primary()[1] == 0x4000000);
-
-        SBigDel(a);
-        SBigDel(b);
     }
 
     SECTION("shifts 0x1000000000000000 right 32 bits") {
-        BigData* a;
-        SBigNew(&a);
-
-        BigData* b;
-        SBigNew(&b);
         uint64_t b_ = 0x1000000000000000;
         SBigFromBinary(b, reinterpret_cast<uint8_t*>(&b_), sizeof(b_));
 
@@ -1334,19 +867,13 @@ TEST_CASE("Shr", "[big]") {
 
         CHECK(a->Primary().Count() == 1);
         CHECK(a->Primary()[0] == 0x10000000);
-
-        SBigDel(a);
-        SBigDel(b);
     }
 }
 
 TEST_CASE("Square", "[big]") {
-    SECTION("squares 0") {
-        BigData* a;
-        SBigNew(&a);
+    BigDataTest a, b;
 
-        BigData* b;
-        SBigNew(&b);
+    SECTION("squares 0") {
         SBigFromUnsigned(b, 0);
 
         Square(a->Primary(), b->Primary(), a->Stack());
@@ -1354,17 +881,9 @@ TEST_CASE("Square", "[big]") {
         a->Primary().Trim();
 
         CHECK(a->Primary().Count() == 0);
-
-        SBigDel(a);
-        SBigDel(b);
     }
 
     SECTION("squares 1") {
-        BigData* a;
-        SBigNew(&a);
-
-        BigData* b;
-        SBigNew(&b);
         SBigFromUnsigned(b, 1);
 
         Square(a->Primary(), b->Primary(), a->Stack());
@@ -1373,17 +892,9 @@ TEST_CASE("Square", "[big]") {
 
         CHECK(a->Primary().Count() == 1);
         CHECK(a->Primary()[0] == 1);
-
-        SBigDel(a);
-        SBigDel(b);
     }
 
     SECTION("squares 2") {
-        BigData* a;
-        SBigNew(&a);
-
-        BigData* b;
-        SBigNew(&b);
         SBigFromUnsigned(b, 2);
 
         Square(a->Primary(), b->Primary(), a->Stack());
@@ -1392,17 +903,9 @@ TEST_CASE("Square", "[big]") {
 
         CHECK(a->Primary().Count() == 1);
         CHECK(a->Primary()[0] == 4);
-
-        SBigDel(a);
-        SBigDel(b);
     }
 
     SECTION("squares 2") {
-        BigData* a;
-        SBigNew(&a);
-
-        BigData* b;
-        SBigNew(&b);
         SBigFromUnsigned(b, 2);
 
         Square(a->Primary(), b->Primary(), a->Stack());
@@ -1411,17 +914,9 @@ TEST_CASE("Square", "[big]") {
 
         CHECK(a->Primary().Count() == 1);
         CHECK(a->Primary()[0] == 4);
-
-        SBigDel(a);
-        SBigDel(b);
     }
 
     SECTION("squares 0xFFFFFFFF") {
-        BigData* a;
-        SBigNew(&a);
-
-        BigData* b;
-        SBigNew(&b);
         SBigFromUnsigned(b, 0xFFFFFFFF);
 
         Square(a->Primary(), b->Primary(), a->Stack());
@@ -1431,17 +926,9 @@ TEST_CASE("Square", "[big]") {
         CHECK(a->Primary().Count() == 2);
         CHECK(a->Primary()[0] == 0x1);
         CHECK(a->Primary()[1] == 0xFFFFFFFE);
-
-        SBigDel(a);
-        SBigDel(b);
     }
 
     SECTION("squares 0x1111111111111111") {
-        BigData* a;
-        SBigNew(&a);
-
-        BigData* b;
-        SBigNew(&b);
         uint64_t b_ = 0x1111111111111111;
         SBigFromBinary(b, reinterpret_cast<uint8_t*>(&b_), sizeof(b_));
 
@@ -1454,9 +941,6 @@ TEST_CASE("Square", "[big]") {
         CHECK(a->Primary()[1] == 0xfedcba9);
         CHECK(a->Primary()[2] == 0x89abcdf0);
         CHECK(a->Primary()[3] == 0x1234567);
-
-        SBigDel(a);
-        SBigDel(b);
     }
 }
 

--- a/test/big/Ops.cpp
+++ b/test/big/Ops.cpp
@@ -68,6 +68,42 @@ TEST_CASE("Add", "[big]") {
     }
 }
 
+TEST_CASE("And", "[big]") {
+    BigDataTest a;
+    BigDataTest b;
+    BigDataTest c;
+
+    SECTION("overwrites output") {
+        SBigFromUnsigned(a, 123456);
+        SBigFromUnsigned(b, 0);
+        SBigFromUnsigned(c, 0);
+
+        And(a->Primary(), b->Primary(), c->Primary());
+
+        CHECK(a->Primary().Count() == 1);
+        CHECK(a->Primary()[0] == 0);
+    }
+
+    SECTION("performs bitwise and on large nums") {
+        uint8_t data[] = {
+            1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 31, 12, 13, 14, 15
+        };
+        uint8_t data2[] = {
+            0, 0, 0, 6, 6, 0, 6, 0, 0, 6, 0xFF, 6, 0, 6, 0
+        };
+        SBigFromBinary(b, data, sizeof(data));
+        SBigFromBinary(c, data2, sizeof(data2));
+
+        And(a->Primary(), b->Primary(), c->Primary());
+
+        CHECK(a->Primary().Count() == 4);
+        CHECK(a->Primary()[0] == 0x04000000);
+        CHECK(a->Primary()[1] == 0x00060004);
+        CHECK(a->Primary()[2] == 0x041F0200);
+        CHECK(a->Primary()[3] == 0x00000600);
+    }
+}
+
 TEST_CASE("Compare", "[big]") {
     SECTION("compares 0 and 1") {
         BigData* a;

--- a/test/big/Ops.cpp
+++ b/test/big/Ops.cpp
@@ -1070,7 +1070,6 @@ TEST_CASE("Sub", "[big]") {
     }
 }
 
-
 TEST_CASE("ToStream", "[big]") {
     BigDataTest a;
 

--- a/test/big/Ops.cpp
+++ b/test/big/Ops.cpp
@@ -1461,16 +1461,10 @@ TEST_CASE("Square", "[big]") {
 }
 
 TEST_CASE("Sub", "[big]") {
+    BigDataTest a, b, c;
+
     SECTION("subtracts 0 from 1") {
-        BigData* a;
-        SBigNew(&a);
-
-        BigData* b;
-        SBigNew(&b);
         SBigFromUnsigned(b, 1);
-
-        BigData* c;
-        SBigNew(&c);
         SBigFromUnsigned(c, 0);
 
         Sub(a->Primary(), b->Primary(), c->Primary());
@@ -1479,21 +1473,40 @@ TEST_CASE("Sub", "[big]") {
 
         CHECK(a->Primary().Count() == 1);
         CHECK(a->Primary()[0] == 1);
+    }
 
-        SBigDel(a);
-        SBigDel(b);
+    SECTION("subtracts int 0 from bigint 1") {
+        SBigFromUnsigned(b, 1);
+
+        Sub(a->Primary(), b->Primary(), 0);
+
+        a->Primary().Trim();
+
+        CHECK(a->Primary().Count() == 1);
+        CHECK(a->Primary()[0] == 1);
+    }
+
+    SECTION("subtracts 1 from 0") {
+        SBigFromUnsigned(b, 0);
+        SBigFromUnsigned(c, 1);
+
+        Sub(a->Primary(), b->Primary(), c->Primary());
+
+        CHECK(a->Primary().Count() == 1);
+        CHECK(a->Primary()[0] == 0xFFFFFFFF);
+    }
+
+    SECTION("subtracts int 1 from bigint 0") {
+        SBigFromUnsigned(b, 0);
+
+        Sub(a->Primary(), b->Primary(), 1);
+
+        CHECK(a->Primary().Count() == 1);
+        CHECK(a->Primary()[0] == 0xFFFFFFFF);
     }
 
     SECTION("subtracts 1 from 2") {
-        BigData* a;
-        SBigNew(&a);
-
-        BigData* b;
-        SBigNew(&b);
         SBigFromUnsigned(b, 2);
-
-        BigData* c;
-        SBigNew(&c);
         SBigFromUnsigned(c, 1);
 
         Sub(a->Primary(), b->Primary(), c->Primary());
@@ -1502,22 +1515,23 @@ TEST_CASE("Sub", "[big]") {
 
         CHECK(a->Primary().Count() == 1);
         CHECK(a->Primary()[0] == 1);
+    }
 
-        SBigDel(a);
-        SBigDel(b);
+    SECTION("subtracts int 1 from bigint 2") {
+        SBigFromUnsigned(b, 2);
+
+        Sub(a->Primary(), b->Primary(), 1);
+
+        a->Primary().Trim();
+
+        CHECK(a->Primary().Count() == 1);
+        CHECK(a->Primary()[0] == 1);
     }
 
     SECTION("subtracts 0x1111111111111111 from 0x9999999999999999") {
-        BigData* a;
-        SBigNew(&a);
-
-        BigData* b;
-        SBigNew(&b);
         uint64_t b_ = 0x9999999999999999;
         SBigFromBinary(b, reinterpret_cast<uint8_t*>(&b_), sizeof(b_));
 
-        BigData* c;
-        SBigNew(&c);
         uint64_t c_ = 0x1111111111111111;
         SBigFromBinary(c, reinterpret_cast<uint8_t*>(&c_), sizeof(c_));
 
@@ -1528,22 +1542,12 @@ TEST_CASE("Sub", "[big]") {
         CHECK(a->Primary().Count() == 2);
         CHECK(a->Primary()[0] == 0x88888888);
         CHECK(a->Primary()[1] == 0x88888888);
-
-        SBigDel(a);
-        SBigDel(b);
     }
 
     SECTION("subtracts 0x123456789ABCDEF0 from 0xFEDCBA9876543210") {
-        BigData* a;
-        SBigNew(&a);
-
-        BigData* b;
-        SBigNew(&b);
         uint64_t b_ = 0xFEDCBA9876543210;
         SBigFromBinary(b, reinterpret_cast<uint8_t*>(&b_), sizeof(b_));
 
-        BigData* c;
-        SBigNew(&c);
         uint64_t c_ = 0x123456789ABCDEF0;
         SBigFromBinary(c, reinterpret_cast<uint8_t*>(&c_), sizeof(c_));
 
@@ -1554,8 +1558,6 @@ TEST_CASE("Sub", "[big]") {
         CHECK(a->Primary().Count() == 2);
         CHECK(a->Primary()[0] == 0xDB975320);
         CHECK(a->Primary()[1] == 0xECA8641F);
-
-        SBigDel(a);
-        SBigDel(b);
     }
+
 }


### PR DESCRIPTION
Implements:

- SBigAnd (ordinal 602)
- SBigCopy (604)
- SBigDec (605)
- SBigDiv (607)
- SBigFromStr (610)
- SBigInc (614)
- SBigIsEven (616)
- SBigIsOdd (617)
- SBigIsOne (618)
- SBigIsZero (620)
- SBigNot (625)
- SBigOr (626)
- SBigXor (647)
- SBigToUnsigned (646)

Also:

- Fixes a compile error with msvc regarding threads.
- Fixes a potential (untested) issue with machine dependent endianness in ExtractLowPartSx.
- Remove a non-retail assertion in the Sub function preventing (originally bugged) below-zero subtraction outcomes. This assert doesn't exist in the 3.3.5a WoW binary nor in other Storm versions such as Starcraft.
- Adds a helper to make SBig tests more concise.
- Fixed some warnings.
