### PR TITLE
chore(region): short circuit redundant unlock calls

### DIFF
--- a/storm/Region.cpp
+++ b/storm/Region.cpp
@@ -168,26 +168,24 @@ void SRgnCombineRectf(HSRGN handle, RECTF* rect, void* param, int32_t combineMod
 
     HLOCKEDRGN lockedHandle;
     auto rgn = s_rgntable.Lock(handle, &lockedHandle, 0);
+    if (!rgn) return;
 
-    if (rgn) {
-        if (combineMode == 2 || combineMode == 6) {
-            if (!IsNullRect(rect)) {
-                rgn->sequence++;
-                AddSourceRect(&rgn->source, rect, param, rgn->sequence, combineMode == 6 ? 0x10000 : 0x0);
-            }
-        } else {
-            if (!IsNullRect(rect)) {
-                rgn->sequence++;
-                FragmentSourceRectangles(&rgn->source, 0, rgn->source.Count(), 0, rect, param, rgn->sequence);
-            }
-
-            ProcessBooleanOperation(&rgn->source, combineMode);
-            OptimizeSource(&rgn->source);
+    if (combineMode == 2 || combineMode == 6) {
+        if (!IsNullRect(rect)) {
+            rgn->sequence++;
+            AddSourceRect(&rgn->source, rect, param, rgn->sequence, combineMode == 6 ? 0x10000 : 0x0);
+        }
+    } else {
+        if (!IsNullRect(rect)) {
+            rgn->sequence++;
+            FragmentSourceRectangles(&rgn->source, 0, rgn->source.Count(), 0, rect, param, rgn->sequence);
         }
 
-        InvalidateRegion(rgn);
+        ProcessBooleanOperation(&rgn->source, combineMode);
+        OptimizeSource(&rgn->source);
     }
 
+    InvalidateRegion(rgn);
     s_rgntable.Unlock(lockedHandle);
 }
 
@@ -226,11 +224,7 @@ void SRgnGetBoundingRectf(HSRGN handle, RECTF* rect) {
 
     HLOCKEDRGN lockedHandle;
     auto rgn = s_rgntable.Lock(handle, &lockedHandle, 0);
-
-    if (!rgn) {
-        s_rgntable.Unlock(lockedHandle);
-        return;
-    }
+    if (!rgn) return;
 
     for (uint32_t i = 0; i < rgn->source.Count(); i++) {
         auto source = &rgn->source[i];


### PR DESCRIPTION
Better matches 0.5.3 and SC. I think the inlining in 3.3.5 caused confusion as the `Lock` call already unlocks it on failure.