### PR TITLE
fix(thread): pthread attributes didn't mirror windows

### DIFF
--- a/storm/thread/CCritSect.cpp
+++ b/storm/thread/CCritSect.cpp
@@ -6,7 +6,11 @@ CCritSect::CCritSect() {
 #endif
 
 #if defined(WHOA_SYSTEM_MAC) || defined(WHOA_SYSTEM_LINUX)
-    pthread_mutex_init(&this->m_critsect, nullptr);
+    pthread_mutexattr_t mutex_attr;
+    pthread_mutexattr_init(&mutex_attr);
+    pthread_mutexattr_settype(&mutex_attr, PTHREAD_MUTEX_RECURSIVE);
+
+    pthread_mutex_init(&this->m_critsect, &mutex_attr);
 #endif
 }
 


### PR DESCRIPTION
Windows' `EnterCriticalSection` allows for recursive calls, pthread does not by default. This lead to a deadlock in https://github.com/whoahq/squall/pull/44 on linux tests in `SRgnDuplicate`.
