### PR TITLE
chore(build): fix compatibility with CMake 4.x

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.1...3.5)
 
 if (${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
     message(FATAL_ERROR


### PR DESCRIPTION
Keeping CMake 3.1 compatibility for now (for old operating systems). I don't believe we're using anything that isn't compatible with 3.5+.