### PR TITLE
chore(build): add WOW and SC1 flavors

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -4,33 +4,42 @@ on: pull_request
 
 jobs:
   build:
-    name: ${{ matrix.config.name }}
-    runs-on: ${{ matrix.config.os }}
+    name: ${{ matrix.flavor.name }} / ${{ matrix.build.os_name }} (${{ matrix.build.compiler_name }})
+    runs-on: ${{ matrix.build.os }}
 
     strategy:
       fail-fast: false
       matrix:
-        config:
-          - name: Ubuntu Latest (GCC)
+        build:
+          - os_name: Ubuntu Latest
+            compiler_name: GCC
             os: ubuntu-latest
             build_type: Release
             test_path: StormTest
             cc: gcc
             cxx: g++
 
-          - name: macOS Latest (Clang)
+          - os_name: macOS Latest
+            compiler_name: Clang
             os: macos-latest
             build_type: Release
             test_path: StormTest
             cc: clang
             cxx: clang++
 
-          - name: Windows Latest (MSVC)
+          - os_name: Windows Latest
+            compiler_name: MSVC
             os: windows-latest
             build_type: Release
             test_path: Release/StormTest
             cc: cl
             cxx: cl
+
+        flavor:
+          - name: WoW
+            define: WOW
+          - name: SC1
+            define: SC1
 
     steps:
       - uses: actions/checkout@v3
@@ -41,10 +50,10 @@ jobs:
         run: mkdir build
 
       - name: Configure
-        run: cd build && cmake .. -DCMAKE_BUILD_TYPE=${{ matrix.config.build_type }}
+        run: cd build && cmake .. -DCMAKE_BUILD_TYPE=${{ matrix.build.build_type }} -DWHOA_STORM_FLAVOR=${{ matrix.flavor.define}}
 
       - name: Build
-        run: cmake --build build --config ${{ matrix.config.build_type }}
+        run: cmake --build build --config ${{ matrix.build.build_type }}
 
       - name: Test
-        run: ./build/test/${{ matrix.config.test_path }}
+        run: ./build/test/${{ matrix.build.test_path }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -7,33 +7,42 @@ on:
 
 jobs:
   build:
-    name: ${{ matrix.config.name }}
-    runs-on: ${{ matrix.config.os }}
+    name: ${{ matrix.flavor.name }} / ${{ matrix.build.os_name }} (${{ matrix.build.compiler_name }})
+    runs-on: ${{ matrix.build.os }}
 
     strategy:
       fail-fast: false
       matrix:
-        config:
-          - name: Ubuntu Latest (GCC)
+        build:
+          - os_name: Ubuntu Latest
+            compiler_name: GCC
             os: ubuntu-latest
             build_type: Release
             test_path: StormTest
             cc: gcc
             cxx: g++
 
-          - name: macOS Latest (Clang)
+          - os_name: macOS Latest
+            compiler_name: Clang
             os: macos-latest
             build_type: Release
             test_path: StormTest
             cc: clang
             cxx: clang++
 
-          - name: Windows Latest (MSVC)
+          - os_name: Windows Latest
+            compiler_name: MSVC
             os: windows-latest
             build_type: Release
             test_path: Release/StormTest
             cc: cl
             cxx: cl
+
+        flavor:
+          - name: WoW
+            define: WOW
+          - name: SC1
+            define: SC1
 
     steps:
       - uses: actions/checkout@v3
@@ -44,10 +53,10 @@ jobs:
         run: mkdir build
 
       - name: Configure
-        run: cd build && cmake .. -DCMAKE_BUILD_TYPE=${{ matrix.config.build_type }}
+        run: cd build && cmake .. -DCMAKE_BUILD_TYPE=${{ matrix.build.build_type }} -DWHOA_STORM_FLAVOR=${{ matrix.flavor.define}}
 
       - name: Build
-        run: cmake --build build --config ${{ matrix.config.build_type }}
+        run: cmake --build build --config ${{ matrix.build.build_type }}
 
       - name: Test
-        run: ./build/test/${{ matrix.config.test_path }}
+        run: ./build/test/${{ matrix.build.test_path }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,17 @@ list(APPEND CMAKE_MODULE_PATH
 
 include(system)
 
+# Storm flavors
+if(WHOA_STORM_FLAVOR STREQUAL "SC1")
+    message(STATUS "Building Storm with StarCraft flavoring")
+
+    add_definitions(-DWHOA_STORM_C_CRIT_SECT_RECURSIVE)
+elseif(WHOA_STORM_FLAVOR STREQUAL "WOW")
+    message(STATUS "Building Storm with World of Warcraft flavoring")
+else()
+    message(STATUS "Building Storm with default flavoring")
+endif()
+
 # OS defines
 if(WHOA_SYSTEM_WIN)
     # Avoid win32 header hell

--- a/storm/thread/CCritSect.cpp
+++ b/storm/thread/CCritSect.cpp
@@ -6,11 +6,18 @@ CCritSect::CCritSect() {
 #endif
 
 #if defined(WHOA_SYSTEM_MAC) || defined(WHOA_SYSTEM_LINUX)
+#if defined(WHOA_STORM_C_CRIT_SECT_RECURSIVE)
+    // Use of SRgnDuplicate on systems with pthreads needs recursive locking (inside s_rgntable) to prevent deadlocks.
+    // This behavior doesn't appear to have carried forward to World of Warcraft, probably because SCritSect was
+    // preferred.
     pthread_mutexattr_t mutex_attr;
     pthread_mutexattr_init(&mutex_attr);
     pthread_mutexattr_settype(&mutex_attr, PTHREAD_MUTEX_RECURSIVE);
 
     pthread_mutex_init(&this->m_critsect, &mutex_attr);
+#else
+    pthread_mutex_init(&this->m_critsect, nullptr);
+#endif
 #endif
 }
 


### PR DESCRIPTION
Since it looks like some aspects of Storm are different enough between StarCraft (SC1) and World of Warcraft, let's add a flavor conditional to control behavior defines. We can use that to modify the behavior of `CCritSect` to match both scenarios.