### PR TITLE
feat(str): implement most remaining SStr functions

### DIFF
--- a/storm/String.cpp
+++ b/storm/String.cpp
@@ -640,11 +640,7 @@ void SStrTokenize(const char** string, char* buffer, size_t bufferchars, const c
     }
 }
 
-double SStrToDouble(const char* string) {
-    STORM_VALIDATE_BEGIN;
-    STORM_VALIDATE(string);
-    STORM_VALIDATE_END;
-
+static inline double ISStrToDouble(const char* string) {
     SStrInitialize();
 
     double result;
@@ -739,103 +735,20 @@ double SStrToDouble(const char* string) {
     return result;
 }
 
+double SStrToDouble(const char* string) {
+    STORM_VALIDATE_BEGIN;
+    STORM_VALIDATE(string);
+    STORM_VALIDATE_END;
+
+    return ISStrToDouble(string);
+}
+
 float SStrToFloat(const char* string) {
     STORM_VALIDATE_BEGIN;
     STORM_VALIDATE(string);
     STORM_VALIDATE_END;
 
-    SStrInitialize();
-
-    double result;
-    bool negative = false;
-
-    if (*string == '-') {
-        negative = true;
-        string++;
-    }
-
-    double v16 = 10.0;
-    double v4 = 0.0;
-    uint32_t v5 = *string - '0';
-    const char* v6 = string;
-
-    if (v5 >= 10) {
-        v5 = 0;
-        result = static_cast<double>(v5);
-    } else {
-        string++;
-
-        uint32_t v8 = *string - '0';
-
-        if (v8 >= 10) {
-            result = static_cast<double>(v5);
-        } else {
-            do {
-                v5 = v8 + 10 * v5;
-                string++;
-
-                if (v5 >= 0x19999999) {
-                    v4 = v4 * pow(10.0, string - v6) + static_cast<double>(v5);
-                    v5 = 0;
-                    v6 = string;
-                }
-
-                v8 = *string - '0';
-            } while (v8 < 10);
-
-            if (v4 == 0.0) {
-                result = static_cast<double>(v5);
-            } else {
-                result = pow(10.0, string - v6) * v4 + static_cast<double>(v5);
-            }
-        }
-    }
-
-    if (*string == '.') {
-        string++;
-
-        uint32_t v23 = *string - '0';
-        int32_t v24 = 0;
-
-        if (v23 < 10) {
-            int32_t v25 = 0;
-            int32_t v26 = -1;
-            double v31;
-
-            do {
-                string++;
-
-                if (v24 < 20) {
-                    v31 = s_realDigit[0][v25 + v23];
-                } else {
-                    v31 = pow(v16, v26) * v23;
-                }
-
-                result += v31;
-
-                v23 = *string - '0';
-                v24++;
-                v26--;
-                v25 += 10;
-            } while (v23 < 10);
-        }
-    }
-
-    if (*string == 'e' || *string == 'E') {
-        const char* v32 = string + 1;
-
-        if (*v32 == '+') {
-            v32++;
-        }
-
-        result *= pow(10.0, SStrToInt(v32));
-    }
-
-    if (negative) {
-        result = -result;
-    }
-
-    return static_cast<float>(result);
+    return static_cast<float>(ISStrToDouble(string));
 }
 
 int32_t SStrToInt(const char* string) {

--- a/storm/String.cpp
+++ b/storm/String.cpp
@@ -553,6 +553,105 @@ void SStrTokenize(const char** string, char* buffer, size_t bufferchars, const c
     }
 }
 
+double SStrToDouble(const char* string) {
+    STORM_VALIDATE_BEGIN;
+    STORM_VALIDATE(string);
+    STORM_VALIDATE_END;
+
+    SStrInitialize();
+
+    double result;
+    bool negative = false;
+
+    if (*string == '-') {
+        negative = true;
+        string++;
+    }
+
+    double v16 = 10.0;
+    double v4 = 0.0;
+    uint32_t v5 = *string - '0';
+    const char* v6 = string;
+
+    if (v5 >= 10) {
+        v5 = 0;
+        result = static_cast<double>(v5);
+    } else {
+        string++;
+
+        uint32_t v8 = *string - '0';
+
+        if (v8 >= 10) {
+            result = static_cast<double>(v5);
+        } else {
+            do {
+                v5 = v8 + 10 * v5;
+                string++;
+
+                if (v5 >= 0x19999999) {
+                    v4 = v4 * pow(10.0, string - v6) + static_cast<double>(v5);
+                    v5 = 0;
+                    v6 = string;
+                }
+
+                v8 = *string - '0';
+            } while (v8 < 10);
+
+            if (v4 == 0.0) {
+                result = static_cast<double>(v5);
+            } else {
+                result = pow(10.0, string - v6) * v4 + static_cast<double>(v5);
+            }
+        }
+    }
+
+    if (*string == '.') {
+        string++;
+
+        uint32_t v23 = *string - '0';
+        int32_t v24 = 0;
+
+        if (v23 < 10) {
+            int32_t v25 = 0;
+            int32_t v26 = -1;
+            double v31;
+
+            do {
+                string++;
+
+                if (v24 < 20) {
+                    v31 = s_realDigit[0][v25 + v23];
+                } else {
+                    v31 = pow(v16, v26) * v23;
+                }
+
+                result += v31;
+
+                v23 = *string - '0';
+                v24++;
+                v26--;
+                v25 += 10;
+            } while (v23 < 10);
+        }
+    }
+
+    if (*string == 'e' || *string == 'E') {
+        const char* v32 = string + 1;
+
+        if (*v32 == '+') {
+            v32++;
+        }
+
+        result *= pow(10.0, SStrToInt(v32));
+    }
+
+    if (negative) {
+        result = -result;
+    }
+
+    return result;
+}
+
 float SStrToFloat(const char* string) {
     STORM_VALIDATE_BEGIN;
     STORM_VALIDATE(string);

--- a/storm/String.cpp
+++ b/storm/String.cpp
@@ -678,6 +678,22 @@ int32_t SStrToInt(const char* string) {
     return result;
 }
 
+uint32_t SStrToUnsigned(const char* string) {
+    STORM_VALIDATE_BEGIN;
+    STORM_VALIDATE(string);
+    STORM_VALIDATE_END;
+
+    uint32_t result = 0;
+
+    uint32_t digit;
+    while ((digit = *string - '0') < 10) {
+        result = digit + (10 * result);
+        string++;
+    }
+
+    return result;
+}
+
 void SStrUpper(char* string) {
     while (*string) {
         *string = static_cast<char>(toupper(*string));

--- a/storm/String.cpp
+++ b/storm/String.cpp
@@ -466,33 +466,36 @@ size_t SStrVPrintf(char* dest, size_t maxchars, const char* format, va_list argl
     return ISStrVPrintf(dest, maxchars, format, arglist);
 }
 
+char* SStrStr(char* string, const char* search) {
+    STORM_VALIDATE_BEGIN;
+    STORM_VALIDATE(string);
+    STORM_VALIDATE(search);
+    STORM_VALIDATE_END;
+
+    size_t searchLength = SStrLen(search);
+
+    for (; *string; string++) {
+        if (!SStrCmp(string, search, searchLength)) {
+            return string;
+        }
+    }
+    return nullptr;
+}
+
 const char* SStrStr(const char* string, const char* search) {
     STORM_VALIDATE_BEGIN;
     STORM_VALIDATE(string);
     STORM_VALIDATE(search);
     STORM_VALIDATE_END;
 
-    if (!*string) {
-        return nullptr;
-    }
+    size_t searchLength = SStrLen(search);
 
-    auto searchEnd = search;
-    while (*searchEnd) {
-        searchEnd++;
-    }
-    size_t searchLength = searchEnd - search;
-
-    auto substring = string;
-
-    while (SStrCmp(substring, search, searchLength)) {
-        substring++;
-
-        if (!*substring) {
-            return nullptr;
+    for (; *string; string++) {
+        if (!SStrCmp(string, search, searchLength)) {
+            return string;
         }
     }
-
-    return substring;
+    return nullptr;
 }
 
 void SStrTokenize(const char** string, char* buffer, size_t bufferchars, const char* whitespace, int32_t* quoted) {

--- a/storm/String.cpp
+++ b/storm/String.cpp
@@ -498,6 +498,38 @@ const char* SStrStr(const char* string, const char* search) {
     return nullptr;
 }
 
+char* SStrStrI(char* string, const char* search) {
+    STORM_VALIDATE_BEGIN;
+    STORM_VALIDATE(string);
+    STORM_VALIDATE(search);
+    STORM_VALIDATE_END;
+
+    size_t searchLength = SStrLen(search);
+
+    for (; *string; string++) {
+        if (!SStrCmpI(string, search, searchLength)) {
+            return string;
+        }
+    }
+    return nullptr;
+}
+
+const char* SStrStrI(const char* string, const char* search) {
+    STORM_VALIDATE_BEGIN;
+    STORM_VALIDATE(string);
+    STORM_VALIDATE(search);
+    STORM_VALIDATE_END;
+
+    size_t searchLength = SStrLen(search);
+
+    for (; *string; string++) {
+        if (!SStrCmpI(string, search, searchLength)) {
+            return string;
+        }
+    }
+    return nullptr;
+}
+
 void SStrTokenize(const char** string, char* buffer, size_t bufferchars, const char* whitespace, int32_t* quoted) {
     STORM_VALIDATE_BEGIN;
     STORM_VALIDATE(string);

--- a/storm/String.cpp
+++ b/storm/String.cpp
@@ -176,7 +176,7 @@ void InitializeFloatDigits() {
     }
 }
 
-size_t ISStrVPrintf(const char* format, va_list va, char* dest, size_t maxchars) {
+size_t ISStrVPrintf(char* dest, size_t maxchars, const char* format, va_list va) {
     if (!maxchars) {
         return 0;
     }
@@ -454,7 +454,16 @@ size_t SStrPrintf(char* dest, size_t maxchars, const char* format, ...) {
     STORM_VALIDATE(format);
     STORM_VALIDATE_END;
 
-    return ISStrVPrintf(format, va, dest, maxchars);
+    return ISStrVPrintf(dest, maxchars, format, va);
+}
+
+size_t SStrVPrintf(char* dest, size_t maxchars, const char* format, va_list arglist) {
+    STORM_VALIDATE_BEGIN;
+    STORM_VALIDATE(dest);
+    STORM_VALIDATE(format);
+    STORM_VALIDATE_END;
+
+    return ISStrVPrintf(dest, maxchars, format, arglist);
 }
 
 const char* SStrStr(const char* string, const char* search) {

--- a/storm/String.hpp
+++ b/storm/String.hpp
@@ -41,6 +41,8 @@ float SStrToFloat(const char* string);
 
 int32_t SStrToInt(const char* string);
 
+uint32_t SStrToUnsigned(const char* string);
+
 void SStrUpper(char* string);
 
 #endif

--- a/storm/String.hpp
+++ b/storm/String.hpp
@@ -37,6 +37,8 @@ const char* SStrStr(const char* string, const char* search);
 
 void SStrTokenize(const char** string, char* buffer, size_t bufferchars, const char* whitespace, int32_t* quoted);
 
+double SStrToDouble(const char* string);
+
 float SStrToFloat(const char* string);
 
 int32_t SStrToInt(const char* string);

--- a/storm/String.hpp
+++ b/storm/String.hpp
@@ -1,6 +1,7 @@
 #ifndef STORM_STRING_HPP
 #define STORM_STRING_HPP
 
+#include <cstdarg>
 #include <cstdint>
 #include <cstdlib>
 
@@ -32,6 +33,8 @@ void SStrLower(char* string);
 uint32_t SStrPack(char* dest, const char* source, uint32_t destsize);
 
 size_t SStrPrintf(char* dest, size_t maxchars, const char* format, ...);
+
+size_t SStrVPrintf(char* dest, size_t maxchars, const char* format, va_list arglist);
 
 const char* SStrStr(const char* string, const char* search);
 

--- a/storm/String.hpp
+++ b/storm/String.hpp
@@ -5,8 +5,12 @@
 #include <cstdint>
 #include <cstdlib>
 
+
 #define STORM_MAX_PATH 260
 #define STORM_MAX_STR 0x7FFFFFFF
+
+#define SSTR_HASH_CASESENSITIVE 1
+
 
 char* SStrChr(char* string, char search);
 
@@ -23,6 +27,8 @@ int32_t SStrCmpI(const char* string1, const char* string2, size_t maxchars = STO
 size_t SStrCopy(char* dest, const char* source, size_t destsize = STORM_MAX_STR);
 
 char* SStrDupA(const char* string, const char* filename, uint32_t linenumber);
+
+uint32_t SStrHash(const char* string, uint32_t flags = 0, uint32_t seed = 0);
 
 uint32_t SStrHashHT(const char* string);
 

--- a/storm/String.hpp
+++ b/storm/String.hpp
@@ -15,11 +15,11 @@ char* SStrChrR(char* string, char search);
 
 const char* SStrChrR(const char* string, char search);
 
-int32_t SStrCmp(const char* string1, const char* string2, size_t maxchars);
+int32_t SStrCmp(const char* string1, const char* string2, size_t maxchars = STORM_MAX_STR);
 
-int32_t SStrCmpI(const char* string1, const char* string2, size_t maxchars);
+int32_t SStrCmpI(const char* string1, const char* string2, size_t maxchars = STORM_MAX_STR);
 
-size_t SStrCopy(char* dest, const char* source, size_t destsize);
+size_t SStrCopy(char* dest, const char* source, size_t destsize = STORM_MAX_STR);
 
 char* SStrDupA(const char* string, const char* filename, uint32_t linenumber);
 

--- a/storm/String.hpp
+++ b/storm/String.hpp
@@ -36,6 +36,8 @@ size_t SStrPrintf(char* dest, size_t maxchars, const char* format, ...);
 
 size_t SStrVPrintf(char* dest, size_t maxchars, const char* format, va_list arglist);
 
+char* SStrStr(char* string, const char* search);
+
 const char* SStrStr(const char* string, const char* search);
 
 void SStrTokenize(const char** string, char* buffer, size_t bufferchars, const char* whitespace, int32_t* quoted);

--- a/storm/String.hpp
+++ b/storm/String.hpp
@@ -40,6 +40,10 @@ char* SStrStr(char* string, const char* search);
 
 const char* SStrStr(const char* string, const char* search);
 
+char* SStrStrI(char* string, const char* search);
+
+const char* SStrStrI(const char* string, const char* search);
+
 void SStrTokenize(const char** string, char* buffer, size_t bufferchars, const char* whitespace, int32_t* quoted);
 
 double SStrToDouble(const char* string);

--- a/test/String.cpp
+++ b/test/String.cpp
@@ -3,6 +3,7 @@
 #include "test/Test.hpp"
 
 #include <cfloat>
+#include <cstdarg>
 #include <type_traits>
 
 
@@ -378,6 +379,56 @@ TEST_CASE("SStrPrintf", "[string]") {
     SECTION("does nothing if maxchars is 0") {
         char dest[10] = {};
         auto length = SStrPrintf(dest, 0, "%d", 69);
+
+        REQUIRE(length == 0);
+        REQUIRE(!SStrCmp(dest, ""));
+    }
+}
+
+static size_t CallSStrVPrintf(char* dest, size_t maxchars, const char* format, ...) {
+    va_list va;
+    va_start(va, format);
+    auto length = SStrVPrintf(dest, maxchars, format, va);
+    va_end(va);
+    return length;
+}
+
+TEST_CASE("SStrVPrintf", "[string]") {
+    SECTION("fills dest with formatted string") {
+        char dest[100] = {};
+        auto length = CallSStrVPrintf(dest, sizeof(dest), "%s - %s", "foo", "bar");
+
+        REQUIRE(length == 9);
+        REQUIRE(!SStrCmp(dest, "foo - bar"));
+    }
+
+    SECTION("fills dest with int") {
+        char dest[100] = {};
+        auto length = CallSStrVPrintf(dest, sizeof(dest), "%d", 69);
+
+        REQUIRE(length == 2);
+        REQUIRE(!SStrCmp(dest, "69"));
+    }
+
+    SECTION("fills dest with empty string") {
+        char dest[100] = {};
+        auto length = CallSStrVPrintf(dest, sizeof(dest), "");
+
+        REQUIRE(length == 0);
+        REQUIRE(!SStrCmp(dest, ""));
+    }
+
+    SECTION("truncates when dest size is not large enough") {
+        char dest[4] = {};
+        auto length = CallSStrVPrintf(dest, sizeof(dest), "%s", "wowzers");
+
+        REQUIRE(length == 3);
+        REQUIRE(!SStrCmp(dest, "wow"));
+    }
+
+    SECTION("does nothing if maxchars is 0") {
+        char dest[10] = {};
+        auto length = CallSStrVPrintf(dest, 0, "%d", 69);
 
         REQUIRE(length == 0);
         REQUIRE(!SStrCmp(dest, ""));

--- a/test/String.cpp
+++ b/test/String.cpp
@@ -374,6 +374,13 @@ TEST_CASE("SStrPrintf", "[string]") {
         REQUIRE(!SStrCmp(dest, "wow"));
     }
 
+    SECTION("does nothing if maxchars is 0") {
+        char dest[10] = {};
+        auto length = SStrPrintf(dest, 0, "%d", 69);
+
+        REQUIRE(length == 0);
+        REQUIRE(!SStrCmp(dest, ""));
+    }
 }
 
 TEST_CASE("SStrStr", "[string]") {
@@ -591,6 +598,53 @@ TEST_CASE("SStrToInt", "[string]") {
     SECTION("converts string with two whitespace-separated numbers to int") {
         auto result = SStrToInt("123 456");
         REQUIRE(result == 123);
+    }
+}
+
+TEST_CASE("SStrToUnsigned", "[string]") {
+    SECTION("converts empty string to int") {
+        auto result = SStrToUnsigned("");
+        REQUIRE(result == 0);
+    }
+
+    SECTION("converts whitespace string to int") {
+        auto result = SStrToUnsigned(" ");
+        REQUIRE(result == 0);
+    }
+
+    SECTION("converts random characters to int") {
+        auto result = SStrToUnsigned("abcd");
+        REQUIRE(result == 0);
+    }
+
+    SECTION("converts string with positive number to int") {
+        auto result = SStrToUnsigned("123");
+        REQUIRE(result == 123);
+    }
+
+    SECTION("returns 0 if number is negative") {
+        auto result = SStrToUnsigned("-123");
+        REQUIRE(result == 0);
+    }
+
+    SECTION("converts string with zero to int") {
+        auto result = SStrToUnsigned("0");
+        REQUIRE(result == 0);
+    }
+
+    SECTION("converts string with leading zero to int") {
+        auto result = SStrToUnsigned("01");
+        REQUIRE(result == 1);
+    }
+
+    SECTION("converts string with two whitespace-separated numbers to int") {
+        auto result = SStrToUnsigned("123 456");
+        REQUIRE(result == 123);
+    }
+
+    SECTION("converts max unsigned int") {
+        auto result = SStrToUnsigned("4294967295");
+        REQUIRE(result == 4294967295u);
     }
 }
 

--- a/test/String.cpp
+++ b/test/String.cpp
@@ -2,76 +2,163 @@
 #include "storm/Memory.hpp"
 #include "test/Test.hpp"
 
-TEST_CASE("SStrChr", "[string]") {
-    auto string = "foobar";
+#include <type_traits>
+
+
+TEST_CASE("SStrChr const", "[string]") {
+    const char* string = "foobar";
+
+    static_assert(std::is_same<decltype(SStrChr(string, 'f')), const char*>::value, "Expect result to be const char*");
 
     SECTION("finds first character when it exists at start of string") {
-        auto result = SStrChr(string, 'f');
+        const char* result = SStrChr(string, 'f');
         REQUIRE(result == string);
     }
 
     SECTION("finds first character when it exists in middle of string") {
-        auto result = SStrChr(string, 'b');
+        const char* result = SStrChr(string, 'b');
         REQUIRE(result == string + 3);
     }
 
     SECTION("finds first character when it exists at end of string") {
-        auto result = SStrChr(string, 'r');
+        const char* result = SStrChr(string, 'r');
         REQUIRE(result == string + 5);
     }
 
     SECTION("returns nullptr when character does not exist in string") {
-        auto result = SStrChr(string, 'z');
+        const char* result = SStrChr(string, 'z');
         REQUIRE(result == nullptr);
     }
 
     SECTION("returns nullptr when string is empty") {
-        auto result = SStrChr("", 'z');
+        const char* result = SStrChr("", 'z');
         REQUIRE(result == nullptr);
     }
 
     SECTION("returns nullptr when character is 0") {
-        auto result = SStrChr(string, '\0');
+        const char* result = SStrChr(string, '\0');
+        REQUIRE(result == nullptr);
+    }
+}
+
+TEST_CASE("SStrChr", "[string]") {
+    char* string = "foobar";
+
+    static_assert(std::is_same<decltype(SStrChr(string, 'f')), char*>::value, "Expect result to be char*");
+
+    SECTION("finds first character when it exists at start of string") {
+        char* result = SStrChr(string, 'f');
+        REQUIRE(result == string);
+    }
+
+    SECTION("finds first character when it exists in middle of string") {
+        char* result = SStrChr(string, 'b');
+        REQUIRE(result == string + 3);
+    }
+
+    SECTION("finds first character when it exists at end of string") {
+        char* result = SStrChr(string, 'r');
+        REQUIRE(result == string + 5);
+    }
+
+    SECTION("returns nullptr when character does not exist in string") {
+        char* result = SStrChr(string, 'z');
+        REQUIRE(result == nullptr);
+    }
+
+    SECTION("returns nullptr when string is empty") {
+        char* string = "";
+        char* result = SStrChr(string, 'z');
+        REQUIRE(result == nullptr);
+    }
+
+    SECTION("returns nullptr when character is 0") {
+        char* result = SStrChr(string, '\0');
+        REQUIRE(result == nullptr);
+    }
+}
+
+TEST_CASE("SStrChrR const", "[string]") {
+    const char* string = "ffoobbaarr";
+
+    static_assert(std::is_same<decltype(SStrChrR(string, 'f')), const char*>::value, "Expect result to be const char*");
+
+    SECTION("finds last character when it exists at start of string") {
+        const char* result = SStrChrR(string, 'f');
+        REQUIRE(result == string + 1);
+    }
+
+    SECTION("finds last character when it exists in middle of string") {
+        const char* result = SStrChrR(string, 'b');
+        REQUIRE(result == string + 5);
+    }
+
+    SECTION("finds last character when it exists at end of string") {
+        const char* result = SStrChrR(string, 'r');
+        REQUIRE(result == string + 9);
+    }
+
+    SECTION("finds last character when it exists at start and end of string") {
+        const char* string = "ffoobbaarrff";
+        const char* result = SStrChrR(string, 'f');
+        REQUIRE(result == string + 11);
+    }
+
+    SECTION("returns nullptr when character does not exist in string") {
+        const char* result = SStrChrR(string, 'z');
+        REQUIRE(result == nullptr);
+    }
+
+    SECTION("returns nullptr when string is empty") {
+        const char* result = SStrChrR("", 'z');
+        REQUIRE(result == nullptr);
+    }
+
+    SECTION("returns nullptr when character is 0") {
+        const char* result = SStrChrR(string, '\0');
         REQUIRE(result == nullptr);
     }
 }
 
 TEST_CASE("SStrChrR", "[string]") {
-    auto string = "ffoobbaarr";
+    char* string = "ffoobbaarr";
+
+    static_assert(std::is_same<decltype(SStrChrR(string, 'f')), char*>::value, "Expect result to be char*");
 
     SECTION("finds last character when it exists at start of string") {
-        auto result = SStrChrR(string, 'f');
+        char* result = SStrChrR(string, 'f');
         REQUIRE(result == string + 1);
     }
 
     SECTION("finds last character when it exists in middle of string") {
-        auto result = SStrChrR(string, 'b');
+        char* result = SStrChrR(string, 'b');
         REQUIRE(result == string + 5);
     }
 
     SECTION("finds last character when it exists at end of string") {
-        auto result = SStrChrR(string, 'r');
+        char* result = SStrChrR(string, 'r');
         REQUIRE(result == string + 9);
     }
 
     SECTION("finds last character when it exists at start and end of string") {
-        auto string = "ffoobbaarrff";
-        auto result = SStrChrR(string, 'f');
+        char* string = "ffoobbaarrff";
+        char* result = SStrChrR(string, 'f');
         REQUIRE(result == string + 11);
     }
 
     SECTION("returns nullptr when character does not exist in string") {
-        auto result = SStrChrR(string, 'z');
+        char* result = SStrChrR(string, 'z');
         REQUIRE(result == nullptr);
     }
 
     SECTION("returns nullptr when string is empty") {
-        auto result = SStrChrR("", 'z');
+        char* string = "";
+        char* result = SStrChrR(string, 'z');
         REQUIRE(result == nullptr);
     }
 
     SECTION("returns nullptr when character is 0") {
-        auto result = SStrChrR(string, '\0');
+        char* result = SStrChrR(string, '\0');
         REQUIRE(result == nullptr);
     }
 }

--- a/test/String.cpp
+++ b/test/String.cpp
@@ -440,6 +440,11 @@ TEST_CASE("SStrStr", "[string]") {
 
     static_assert(std::is_same<decltype(SStrStr(string, "")), char*>::value, "Expect result to be char*");
 
+    SECTION("is case sensitive") {
+        char* substring = SStrStr(string, "OOBA");
+        REQUIRE(substring == nullptr);
+    }
+
     SECTION("finds substring when it exists at end of string") {
         char* substring = SStrStr(string, "bar");
         REQUIRE(substring == string + 3);
@@ -472,6 +477,11 @@ TEST_CASE("SStrStr const", "[string]") {
 
     static_assert(std::is_same<decltype(SStrStr(string, "")), const char*>::value, "Expect result to be const char*");
 
+    SECTION("is case sensitive") {
+        const char* substring = SStrStr(string, "OOBA");
+        REQUIRE(substring == nullptr);
+    }
+
     SECTION("finds substring when it exists at end of string") {
         const char* substring = SStrStr(string, "bar");
         REQUIRE(substring == string + 3);
@@ -494,6 +504,79 @@ TEST_CASE("SStrStr const", "[string]") {
 
     SECTION("returns nullptr when given empty string") {
         const char* substring = SStrStr("", "bar");
+        REQUIRE(substring == nullptr);
+    }
+}
+
+TEST_CASE("SStrStrI", "[string]") {
+    char* string = "foobar";
+
+    static_assert(std::is_same<decltype(SStrStrI(string, "")), char*>::value, "Expect result to be char*");
+
+    SECTION("is case insensitive") {
+        char* substring = SStrStrI(string, "OOBA");
+        REQUIRE(substring == string + 1);
+    }
+
+    SECTION("finds substring when it exists at end of string") {
+        char* substring = SStrStrI(string, "bar");
+        REQUIRE(substring == string + 3);
+    }
+
+    SECTION("finds substring when it exists at start of string") {
+        char* substring = SStrStrI(string, "foo");
+        REQUIRE(substring == string);
+    }
+
+    SECTION("finds substring when search is empty") {
+        char* substring = SStrStrI(string, "");
+        REQUIRE(substring == string);
+    }
+
+    SECTION("returns nullptr when search does not exist in string") {
+        char* substring = SStrStrI(string, "xyzzy");
+        REQUIRE(substring == nullptr);
+    }
+
+    SECTION("returns nullptr when given empty string") {
+        char* string = "";
+        char* substring = SStrStrI(string, "bar");
+        REQUIRE(substring == nullptr);
+    }
+}
+
+TEST_CASE("SStrStrI const", "[string]") {
+    const char* string = "foobar";
+
+    static_assert(std::is_same<decltype(SStrStrI(string, "")), const char*>::value, "Expect result to be const char*");
+
+    SECTION("is case insensitive") {
+        const char* substring = SStrStrI(string, "OOBA");
+        REQUIRE(substring == string + 1);
+    }
+
+    SECTION("finds substring when it exists at end of string") {
+        const char* substring = SStrStrI(string, "bar");
+        REQUIRE(substring == string + 3);
+    }
+
+    SECTION("finds substring when it exists at start of string") {
+        const char* substring = SStrStrI(string, "foo");
+        REQUIRE(substring == string);
+    }
+
+    SECTION("finds substring when search is empty") {
+        const char* substring = SStrStrI(string, "");
+        REQUIRE(substring == string);
+    }
+
+    SECTION("returns nullptr when search does not exist in string") {
+        const char* substring = SStrStrI(string, "xyzzy");
+        REQUIRE(substring == nullptr);
+    }
+
+    SECTION("returns nullptr when given empty string") {
+        const char* substring = SStrStrI("", "bar");
         REQUIRE(substring == nullptr);
     }
 }

--- a/test/String.cpp
+++ b/test/String.cpp
@@ -436,32 +436,64 @@ TEST_CASE("SStrVPrintf", "[string]") {
 }
 
 TEST_CASE("SStrStr", "[string]") {
-    auto string = "foobar";
+    char* string = "foobar";
+
+    static_assert(std::is_same<decltype(SStrStr(string, "")), char*>::value, "Expect result to be char*");
 
     SECTION("finds substring when it exists at end of string") {
-        auto search = "bar";
-        auto substring = SStrStr(string, search);
+        char* substring = SStrStr(string, "bar");
         REQUIRE(substring == string + 3);
     }
 
     SECTION("finds substring when it exists at start of string") {
-        auto search = "foo";
-        auto substring = SStrStr(string, search);
+        char* substring = SStrStr(string, "foo");
         REQUIRE(substring == string);
     }
 
     SECTION("finds substring when search is empty") {
-        auto substring = SStrStr(string, "");
+        char* substring = SStrStr(string, "");
         REQUIRE(substring == string);
     }
 
     SECTION("returns nullptr when search does not exist in string") {
-        auto substring = SStrStr(string, "xyzzy");
+        char* substring = SStrStr(string, "xyzzy");
         REQUIRE(substring == nullptr);
     }
 
     SECTION("returns nullptr when given empty string") {
-        auto substring = SStrStr("", "bar");
+        char* string = "";
+        char* substring = SStrStr(string, "bar");
+        REQUIRE(substring == nullptr);
+    }
+}
+
+TEST_CASE("SStrStr const", "[string]") {
+    const char* string = "foobar";
+
+    static_assert(std::is_same<decltype(SStrStr(string, "")), const char*>::value, "Expect result to be const char*");
+
+    SECTION("finds substring when it exists at end of string") {
+        const char* substring = SStrStr(string, "bar");
+        REQUIRE(substring == string + 3);
+    }
+
+    SECTION("finds substring when it exists at start of string") {
+        const char* substring = SStrStr(string, "foo");
+        REQUIRE(substring == string);
+    }
+
+    SECTION("finds substring when search is empty") {
+        const char* substring = SStrStr(string, "");
+        REQUIRE(substring == string);
+    }
+
+    SECTION("returns nullptr when search does not exist in string") {
+        const char* substring = SStrStr(string, "xyzzy");
+        REQUIRE(substring == nullptr);
+    }
+
+    SECTION("returns nullptr when given empty string") {
+        const char* substring = SStrStr("", "bar");
         REQUIRE(substring == nullptr);
     }
 }

--- a/test/String.cpp
+++ b/test/String.cpp
@@ -2,6 +2,7 @@
 #include "storm/Memory.hpp"
 #include "test/Test.hpp"
 
+#include <cfloat>
 #include <type_traits>
 
 
@@ -487,6 +488,84 @@ TEST_CASE("SStrTokenize", "[string]") {
     }
 }
 
+TEST_CASE("SStrToDouble", "[string]") {
+    SECTION("converts empty string to double") {
+        auto result = SStrToDouble("");
+        REQUIRE(result == 0.0f);
+    }
+
+    SECTION("converts whitespace string to double") {
+        auto result = SStrToDouble(" \t\r\n");
+        REQUIRE(result == 0.0f);
+    }
+
+    SECTION("converts random characters to double") {
+        auto result = SStrToDouble("abcd");
+        REQUIRE(result == 0.0f);
+    }
+
+    SECTION("converts string with positive int to double") {
+        auto result = SStrToDouble("123");
+        REQUIRE(result == 123.0f);
+    }
+
+    SECTION("converts string with negative int to double") {
+        auto result = SStrToDouble("-123");
+        REQUIRE(result == -123.0f);
+    }
+
+    SECTION("converts string with positive float to double") {
+        auto result = SStrToDouble("1.5");
+        REQUIRE(result == 1.5f);
+    }
+
+    SECTION("converts string with negative float to double") {
+        auto result = SStrToDouble("-1.5");
+        REQUIRE(result == -1.5f);
+    }
+
+    SECTION("converts string with float and positive exponent to double") {
+        auto result = SStrToDouble("1.5e3");
+        REQUIRE(result == 1500.0f);
+    }
+
+    SECTION("converts string with float and positive full form exponent to double") {
+        auto result = SStrToDouble("1.5e+3");
+        REQUIRE(result == 1500.0f);
+    }
+
+    SECTION("converts string with capital exponent to double") {
+        auto result = SStrToDouble("1.5E+3");
+        REQUIRE(result == 1500.0f);
+    }
+
+    SECTION("converts string with random added letter to double") {
+        auto result = SStrToDouble("1.5g3");
+        REQUIRE(result == 1.5f);
+    }
+
+    SECTION("converts string with float and negative exponent to double") {
+        auto result = SStrToDouble("1500.0e-3");
+        REQUIRE(result == 1.5f);
+    }
+
+    SECTION("converts string with zero to double") {
+        auto result = SStrToDouble("0");
+        REQUIRE(result == 0.0f);
+    }
+
+    SECTION("converts string with leading zero to double") {
+        auto result = SStrToDouble("01");
+        REQUIRE(result == 1.0f);
+    }
+
+    SECTION("converts large values to infinity") {
+        // beyond max double
+        REQUIRE(SStrToDouble("1.79769e+310") == HUGE_VAL);
+        REQUIRE(SStrToDouble("-1.79769e+310") == -HUGE_VAL);
+    }
+}
+
 TEST_CASE("SStrToFloat", "[string]") {
     SECTION("converts empty string to float") {
         auto result = SStrToFloat("");
@@ -556,6 +635,15 @@ TEST_CASE("SStrToFloat", "[string]") {
     SECTION("converts string with leading zero to float") {
         auto result = SStrToFloat("01");
         REQUIRE(result == 1.0f);
+    }
+
+    SECTION("converts large values to infinity") {
+        // max double
+        REQUIRE(SStrToFloat("1.79769e+308") == HUGE_VALF);
+
+        // beyond max double
+        REQUIRE(SStrToFloat("1.79769e+310") == HUGE_VALF);
+        REQUIRE(SStrToFloat("-1.79769e+310") == -HUGE_VALF);
     }
 }
 

--- a/test/String.cpp
+++ b/test/String.cpp
@@ -3,119 +3,134 @@
 #include "test/Test.hpp"
 
 TEST_CASE("SStrChr", "[string]") {
+    auto string = "foobar";
+
     SECTION("finds first character when it exists at start of string") {
-        auto string = "foobar";
-        auto search = 'f';
-        auto result = SStrChr(string, search);
+        auto result = SStrChr(string, 'f');
         REQUIRE(result == string);
     }
 
     SECTION("finds first character when it exists in middle of string") {
-        auto string = "foobar";
-        auto search = 'b';
-        auto result = SStrChr(string, search);
+        auto result = SStrChr(string, 'b');
         REQUIRE(result == string + 3);
     }
 
     SECTION("finds first character when it exists at end of string") {
-        auto string = "foobar";
-        auto search = 'r';
-        auto result = SStrChr(string, search);
+        auto result = SStrChr(string, 'r');
         REQUIRE(result == string + 5);
     }
 
     SECTION("returns nullptr when character does not exist in string") {
-        auto string = "foobar";
-        auto search = 'z';
-        auto result = SStrChr(string, search);
+        auto result = SStrChr(string, 'z');
         REQUIRE(result == nullptr);
     }
 
     SECTION("returns nullptr when string is empty") {
-        auto string = "";
-        auto search = 'z';
-        auto result = SStrChr(string, search);
+        auto result = SStrChr("", 'z');
+        REQUIRE(result == nullptr);
+    }
+
+    SECTION("returns nullptr when character is 0") {
+        auto result = SStrChr(string, '\0');
         REQUIRE(result == nullptr);
     }
 }
 
 TEST_CASE("SStrChrR", "[string]") {
+    auto string = "ffoobbaarr";
+
     SECTION("finds last character when it exists at start of string") {
-        auto string = "ffoobbaarr";
-        auto search = 'f';
-        auto result = SStrChrR(string, search);
+        auto result = SStrChrR(string, 'f');
         REQUIRE(result == string + 1);
     }
 
     SECTION("finds last character when it exists in middle of string") {
-        auto string = "ffoobbaarr";
-        auto search = 'b';
-        auto result = SStrChrR(string, search);
+        auto result = SStrChrR(string, 'b');
         REQUIRE(result == string + 5);
     }
 
     SECTION("finds last character when it exists at end of string") {
-        auto string = "ffoobbaarr";
-        auto search = 'r';
-        auto result = SStrChrR(string, search);
+        auto result = SStrChrR(string, 'r');
         REQUIRE(result == string + 9);
     }
 
     SECTION("finds last character when it exists at start and end of string") {
         auto string = "ffoobbaarrff";
-        auto search = 'f';
-        auto result = SStrChrR(string, search);
+        auto result = SStrChrR(string, 'f');
         REQUIRE(result == string + 11);
     }
 
     SECTION("returns nullptr when character does not exist in string") {
-        auto string = "ffoobbaarr";
-        auto search = 'z';
-        auto result = SStrChrR(string, search);
+        auto result = SStrChrR(string, 'z');
         REQUIRE(result == nullptr);
     }
 
     SECTION("returns nullptr when string is empty") {
-        auto string = "";
-        auto search = 'z';
-        auto result = SStrChrR(string, search);
+        auto result = SStrChrR("", 'z');
+        REQUIRE(result == nullptr);
+    }
+
+    SECTION("returns nullptr when character is 0") {
+        auto result = SStrChrR(string, '\0');
         REQUIRE(result == nullptr);
     }
 }
 
 TEST_CASE("SStrCmp", "[string]") {
     SECTION("compares two strings that exactly match correctly") {
-        auto compare = SStrCmp("foo", "foo", STORM_MAX_STR);
+        auto compare = SStrCmp("foo", "foo");
         REQUIRE(compare == 0);
     }
 
     SECTION("compares two strings that partially match correctly") {
-        auto compare1 = SStrCmp("bar", "foobar", STORM_MAX_STR);
-        auto compare2 = SStrCmp("foobar", "bar", STORM_MAX_STR);
+        auto compare1 = SStrCmp("bar", "foobar");
+        auto compare2 = SStrCmp("foobar", "bar");
         REQUIRE(compare1 < 0);
         REQUIRE(compare2 > 0);
     }
 
     SECTION("compares two strings that do not match correctly") {
-        auto compare = SStrCmp("bar", "xyzzy", STORM_MAX_STR);
+        auto compare = SStrCmp("bar", "xyzzy");
         REQUIRE(compare < 0);
+    }
+
+    SECTION("only compares up to maxchars") {
+        auto compare = SStrCmp("donkeykong", "donkeypinnochio", 6);
+        REQUIRE(compare == 0);
+    }
+
+    SECTION("compare is case sensitive") {
+        auto compare = SStrCmp("dingdong", "dInGdOnG");
+        REQUIRE(compare != 0);
     }
 }
 
 TEST_CASE("SStrCmpI", "[string]") {
     SECTION("compares two strings that exactly match correctly") {
-        auto compare = SStrCmpI("foo", "foo", STORM_MAX_STR);
+        auto compare = SStrCmpI("foo", "foo");
         REQUIRE(compare == 0);
     }
 
     SECTION("compares two strings that match with differing case correctly") {
-        auto compare = SStrCmpI("foo", "foO", STORM_MAX_STR);
+        auto compare = SStrCmpI("foo", "FoO");
         REQUIRE(compare == 0);
     }
 
+    SECTION("compares two strings that partially match correctly") {
+        auto compare1 = SStrCmpI("bar", "foobar");
+        auto compare2 = SStrCmpI("foobar", "bar");
+        REQUIRE(compare1 < 0);
+        REQUIRE(compare2 > 0);
+    }
+
     SECTION("compares two strings that do not match correctly") {
-        auto compare = SStrCmpI("bar", "xyzzy", STORM_MAX_STR);
+        auto compare = SStrCmpI("bar", "xyzzy");
         REQUIRE(compare < 0);
+    }
+
+    SECTION("only compares up to maxchars") {
+        auto compare = SStrCmpI("donkeykong", "donkeypinnochio", 6);
+        REQUIRE(compare == 0);
     }
 }
 
@@ -123,7 +138,18 @@ TEST_CASE("SStrDupA", "[string]") {
     SECTION("duplicates string correctly") {
         auto string1 = "foo bar";
         auto string2 = SStrDupA(string1, __FILE__, __LINE__);
-        auto compare = SStrCmp(string1, string2, STORM_MAX_STR);
+        auto compare = SStrCmp(string1, string2);
+        auto newPtr = string1 != string2;
+        SMemFree(string2);
+
+        REQUIRE(compare == 0);
+        REQUIRE(newPtr == true);
+    }
+
+    SECTION("duplicates empty string correctly") {
+        auto string1 = "";
+        auto string2 = SStrDupA(string1, __FILE__, __LINE__);
+        auto compare = SStrCmp(string1, string2);
         auto newPtr = string1 != string2;
         SMemFree(string2);
 
@@ -152,112 +178,144 @@ TEST_CASE("SStrHashHT", "[string]") {
 
 TEST_CASE("SStrLen", "[string]") {
     SECTION("calculates string length correctly") {
-        auto length = SStrLen("foo");
-        REQUIRE(length == 3);
+        REQUIRE(SStrLen("foo") == 3);
+    }
+
+    SECTION("calculates empty string length correctly") {
+        REQUIRE(SStrLen("") == 0);
     }
 }
 
 TEST_CASE("SStrLower", "[string]") {
     SECTION("rewrites uppercase string to lowercase correctly") {
-        auto upper = "FOOBAR";
-        char* lower = static_cast<char*>(SMemAlloc(SStrLen(upper) + 1, __FILE__, __LINE__, 0x0));
-        SStrCopy(lower, upper, STORM_MAX_STR);
-        SStrLower(lower);
-        auto compare = SStrCmp(lower, "foobar", SStrLen(lower));
-        SMemFree(lower);
+        char string[] = "FOOBAR";
+        SStrLower(string);
 
-        REQUIRE(!compare);
+        REQUIRE(!SStrCmp(string, "foobar"));
     }
 
     SECTION("rewrites lowercase string to lowercase correctly") {
-        auto lower1 = "foobar";
-        char* lower2 = static_cast<char*>(SMemAlloc(SStrLen(lower1) + 1, __FILE__, __LINE__, 0x0));
-        SStrCopy(lower2, lower1, STORM_MAX_STR);
-        SStrLower(lower2);
-        auto compare = SStrCmp(lower2, "foobar", SStrLen(lower2));
-        SMemFree(lower2);
+        char string[] = "foobar";
+        SStrLower(string);
 
-        REQUIRE(!compare);
+        REQUIRE(!SStrCmp(string, "foobar"));
+    }
+
+    SECTION("does nothing on empty string") {
+        char string[] = "";
+        SStrLower(string);
+
+        REQUIRE(!SStrCmp(string, ""));
     }
 }
 
 TEST_CASE("SStrPack", "[string]") {
     SECTION("truncates dest correctly when first byte in source is null") {
-        char dest[10] = { 0 };
+        char dest[10] = {};
         auto source = "\0foobar";
-        auto length = SStrPack(dest, source, 10);
+        auto length = SStrPack(dest, source, sizeof(dest));
+
         REQUIRE(length == 0);
-        REQUIRE(!SStrCmp(dest, "", SStrLen("")));
+        REQUIRE(!SStrCmp(dest, ""));
     }
 
     SECTION("truncates dest correctly when middle byte in source is null") {
-        char dest[10] = { 0 };
+        char dest[10] = {};
         auto source = "foo\0bar";
-        auto length = SStrPack(dest, source, 10);
+        auto length = SStrPack(dest, source, sizeof(dest));
+
         REQUIRE(length == 3);
-        REQUIRE(!SStrCmp(dest, "foo", SStrLen("foo")));
+        REQUIRE(!SStrCmp(dest, "foo"));
     }
 
     SECTION("does not truncate dest when source has no early null byte") {
-        char dest[10] = { 0 };
+        char dest[10] = {};
         auto source = "foobar";
-        auto length = SStrPack(dest, source, 10);
+        auto length = SStrPack(dest, source, sizeof(dest));
+
         REQUIRE(length == 6);
-        REQUIRE(!SStrCmp(dest, "foobar", SStrLen("foobar")));
+        REQUIRE(!SStrCmp(dest, "foobar"));
+    }
+
+    SECTION("appends to target string") {
+        char dest[10] = "who";
+        auto length = SStrPack(dest, "dis", sizeof(dest));
+
+        REQUIRE(length == 6);
+        REQUIRE(!SStrCmp(dest, "whodis"));
+    }
+
+    SECTION("truncates when dest size is not large enough") {
+        char dest[5] = "who";
+        auto length = SStrPack(dest, "dis", sizeof(dest));
+
+        REQUIRE(length == 4);
+        REQUIRE(!SStrCmp(dest, "whod"));
     }
 }
 
 TEST_CASE("SStrPrintf", "[string]") {
     SECTION("fills dest with formatted string") {
-        char dest[100] = { 0 };
-        auto format = "%s - %s";
-        auto length = SStrPrintf(dest, 100, format, "foo", "bar");
+        char dest[100] = {};
+        auto length = SStrPrintf(dest, sizeof(dest), "%s - %s", "foo", "bar");
+
         REQUIRE(length == 9);
-        REQUIRE(!SStrCmp(dest, "foo - bar", SStrLen("foo - bar")));
+        REQUIRE(!SStrCmp(dest, "foo - bar"));
+    }
+
+    SECTION("fills dest with int") {
+        char dest[100] = {};
+        auto length = SStrPrintf(dest, sizeof(dest), "%d", 69);
+
+        REQUIRE(length == 2);
+        REQUIRE(!SStrCmp(dest, "69"));
     }
 
     SECTION("fills dest with empty string") {
-        char dest[100] = { 0 };
-        auto format = "";
-        auto length = SStrPrintf(dest, 100, format);
+        char dest[100] = {};
+        auto length = SStrPrintf(dest, sizeof(dest), "");
+
         REQUIRE(length == 0);
-        REQUIRE(!SStrCmp(dest, "", SStrLen("")));
+        REQUIRE(!SStrCmp(dest, ""));
     }
+
+    SECTION("truncates when dest size is not large enough") {
+        char dest[4] = {};
+        auto length = SStrPrintf(dest, sizeof(dest), "%s", "wowzers");
+
+        REQUIRE(length == 3);
+        REQUIRE(!SStrCmp(dest, "wow"));
+    }
+
 }
 
 TEST_CASE("SStrStr", "[string]") {
+    auto string = "foobar";
+
     SECTION("finds substring when it exists at end of string") {
-        auto string = "foobar";
         auto search = "bar";
         auto substring = SStrStr(string, search);
-        REQUIRE(!SStrCmp(search, substring, SStrLen(search)));
+        REQUIRE(substring == string + 3);
     }
 
     SECTION("finds substring when it exists at start of string") {
-        auto string = "foobar";
         auto search = "foo";
         auto substring = SStrStr(string, search);
-        REQUIRE(!SStrCmp(search, substring, SStrLen(search)));
+        REQUIRE(substring == string);
     }
 
     SECTION("finds substring when search is empty") {
-        auto string = "foobar";
-        auto search = "";
-        auto substring = SStrStr(string, search);
-        REQUIRE(!SStrCmp(string, substring, SStrLen(string)));
+        auto substring = SStrStr(string, "");
+        REQUIRE(substring == string);
     }
 
     SECTION("returns nullptr when search does not exist in string") {
-        auto string = "foobar";
-        auto search = "xyzzy";
-        auto substring = SStrStr(string, search);
+        auto substring = SStrStr(string, "xyzzy");
         REQUIRE(substring == nullptr);
     }
 
     SECTION("returns nullptr when given empty string") {
-        auto string = "";
-        auto search = "bar";
-        auto substring = SStrStr(string, search);
+        auto substring = SStrStr("", "bar");
         REQUIRE(substring == nullptr);
     }
 }
@@ -265,36 +323,36 @@ TEST_CASE("SStrStr", "[string]") {
 TEST_CASE("SStrTokenize", "[string]") {
     SECTION("finds all tokens in comma-delimited string") {
         auto string = "foo,bar,baz";
-        char buffer[100] = { 0 };
+        char buffer[100] = {};
         const char* tokens[] = { "foo", "bar", "baz" };
 
         for (auto& token : tokens) {
-            SStrTokenize(&string, buffer, 1000, " ,", nullptr);
-            REQUIRE(!SStrCmp(buffer, token, STORM_MAX_STR));
+            SStrTokenize(&string, buffer, sizeof(buffer), " ,", nullptr);
+            REQUIRE(!SStrCmp(buffer, token));
         }
     }
 
     SECTION("finds all tokens in comma-and-whitespace-delimited string") {
         auto string = "foo , bar , baz";
-        char buffer[100] = { 0 };
+        char buffer[100] = {};
         const char* tokens[] = { "foo", "bar", "baz" };
 
         for (auto& token : tokens) {
-            SStrTokenize(&string, buffer, 1000, " ,", nullptr);
-            REQUIRE(!SStrCmp(buffer, token, STORM_MAX_STR));
+            SStrTokenize(&string, buffer, sizeof(buffer), " ,", nullptr);
+            REQUIRE(!SStrCmp(buffer, token));
         }
     }
 
     SECTION("finds no tokens empty string") {
         auto string = "";
-        char buffer[100] = { 0 };
-        SStrTokenize(&string, buffer, 1000, " ,", nullptr);
-        REQUIRE(!SStrCmp(buffer, "", STORM_MAX_STR));
+        char buffer[100] = {};
+        SStrTokenize(&string, buffer, sizeof(buffer), " ,", nullptr);
+        REQUIRE(!SStrCmp(buffer, ""));
     }
 
     SECTION("identifies quoted tokens") {
         auto string = "foo bar \"baz bazinga\" bodonkers \"donga dongs\"";
-        char buffer[100] = { 0 };
+        char buffer[100] = {};
         std::pair<const char*, int> tokens[] = {
             std::make_pair("foo", 0),
             std::make_pair("bar", 0),
@@ -305,7 +363,7 @@ TEST_CASE("SStrTokenize", "[string]") {
 
         for (auto& token : tokens) {
             int quoted = 0;
-            SStrTokenize(&string, buffer, 1000, " \"", &quoted);
+            SStrTokenize(&string, buffer, sizeof(buffer), " \"", &quoted);
             std::string result = buffer;
             REQUIRE(result == token.first);
             REQUIRE(quoted == token.second);
@@ -314,7 +372,7 @@ TEST_CASE("SStrTokenize", "[string]") {
 
     SECTION("doesn't identify quoted tokens if excluded from whitespace") {
         auto string = "foo bar \"baz bazinga\" bodonkers \"donga dongs\"";
-        char buffer[100] = { 0 };
+        char buffer[100] = {};
         std::pair<const char*, int> tokens[] = {
             std::make_pair("foo", 0),
             std::make_pair("bar", 0),
@@ -327,7 +385,7 @@ TEST_CASE("SStrTokenize", "[string]") {
 
         for (auto& token : tokens) {
             int quoted = 0;
-            SStrTokenize(&string, buffer, 1000, " ", &quoted);
+            SStrTokenize(&string, buffer, sizeof(buffer), " ", &quoted);
             std::string result = buffer;
             REQUIRE(result == token.first);
             REQUIRE(quoted == token.second);
@@ -337,130 +395,137 @@ TEST_CASE("SStrTokenize", "[string]") {
 
 TEST_CASE("SStrToFloat", "[string]") {
     SECTION("converts empty string to float") {
-        auto string = "";
-        auto result = SStrToFloat(string);
+        auto result = SStrToFloat("");
         REQUIRE(result == 0.0f);
     }
 
     SECTION("converts whitespace string to float") {
-        auto string = " ";
-        auto result = SStrToFloat(string);
+        auto result = SStrToFloat(" \t\r\n");
+        REQUIRE(result == 0.0f);
+    }
+
+    SECTION("converts random characters to float") {
+        auto result = SStrToFloat("abcd");
         REQUIRE(result == 0.0f);
     }
 
     SECTION("converts string with positive int to float") {
-        auto string = "123";
-        auto result = SStrToFloat(string);
+        auto result = SStrToFloat("123");
         REQUIRE(result == 123.0f);
     }
 
     SECTION("converts string with negative int to float") {
-        auto string = "-123";
-        auto result = SStrToFloat(string);
+        auto result = SStrToFloat("-123");
         REQUIRE(result == -123.0f);
     }
 
     SECTION("converts string with positive float to float") {
-        auto string = "1.5";
-        auto result = SStrToFloat(string);
+        auto result = SStrToFloat("1.5");
         REQUIRE(result == 1.5f);
     }
 
     SECTION("converts string with negative float to float") {
-        auto string = "-1.5";
-        auto result = SStrToFloat(string);
+        auto result = SStrToFloat("-1.5");
         REQUIRE(result == -1.5f);
     }
 
     SECTION("converts string with float and positive exponent to float") {
-        auto string = "1.5e3";
-        auto result = SStrToFloat(string);
+        auto result = SStrToFloat("1.5e3");
         REQUIRE(result == 1500.0f);
     }
 
+    SECTION("converts string with float and positive full form exponent to float") {
+        auto result = SStrToFloat("1.5e+3");
+        REQUIRE(result == 1500.0f);
+    }
+
+    SECTION("converts string with capital exponent to float") {
+        auto result = SStrToFloat("1.5E+3");
+        REQUIRE(result == 1500.0f);
+    }
+
+    SECTION("converts string with random added letter to float") {
+        auto result = SStrToFloat("1.5g3");
+        REQUIRE(result == 1.5f);
+    }
+
     SECTION("converts string with float and negative exponent to float") {
-        auto string = "1500.0e-3";
-        auto result = SStrToFloat(string);
+        auto result = SStrToFloat("1500.0e-3");
         REQUIRE(result == 1.5f);
     }
 
     SECTION("converts string with zero to float") {
-        auto string = "0";
-        auto result = SStrToFloat(string);
+        auto result = SStrToFloat("0");
         REQUIRE(result == 0.0f);
     }
 
     SECTION("converts string with leading zero to float") {
-        auto string = "01";
-        auto result = SStrToFloat(string);
+        auto result = SStrToFloat("01");
         REQUIRE(result == 1.0f);
     }
 }
 
 TEST_CASE("SStrToInt", "[string]") {
     SECTION("converts empty string to int") {
-        auto string = "";
-        auto result = SStrToInt(string);
+        auto result = SStrToInt("");
         REQUIRE(result == 0);
     }
 
     SECTION("converts whitespace string to int") {
-        auto string = " ";
-        auto result = SStrToInt(string);
+        auto result = SStrToInt(" ");
+        REQUIRE(result == 0);
+    }
+
+    SECTION("converts random characters to int") {
+        auto result = SStrToInt("abcd");
         REQUIRE(result == 0);
     }
 
     SECTION("converts string with positive number to int") {
-        auto string = "123";
-        auto result = SStrToInt(string);
+        auto result = SStrToInt("123");
         REQUIRE(result == 123);
     }
 
     SECTION("converts string with negative number to int") {
-        auto string = "-123";
-        auto result = SStrToInt(string);
+        auto result = SStrToInt("-123");
         REQUIRE(result == -123);
     }
 
     SECTION("converts string with zero to int") {
-        auto string = "0";
-        auto result = SStrToInt(string);
+        auto result = SStrToInt("0");
         REQUIRE(result == 0);
     }
 
     SECTION("converts string with leading zero to int") {
-        auto string = "01";
-        auto result = SStrToInt(string);
+        auto result = SStrToInt("01");
         REQUIRE(result == 1);
     }
 
     SECTION("converts string with two whitespace-separated numbers to int") {
-        auto string = "123 456";
-        auto result = SStrToInt(string);
+        auto result = SStrToInt("123 456");
         REQUIRE(result == 123);
     }
 }
 
 TEST_CASE("SStrUpper", "[string]") {
     SECTION("rewrites lowercase string to uppercase correctly") {
-        auto lower = "foobar";
-        auto upper = static_cast<char*>(SMemAlloc(SStrLen(lower) + 1, __FILE__, __LINE__, 0x0));
-        SStrCopy(upper, lower, STORM_MAX_STR);
-        SStrUpper(upper);
-        auto compare = SStrCmp(upper, "FOOBAR", SStrLen(upper));
-        SMemFree(upper);
+        char string[] = "foobar";
+        SStrUpper(string);
 
-        REQUIRE(!compare);
+        REQUIRE(!SStrCmp(string, "FOOBAR"));
     }
 
     SECTION("rewrites uppercase string to uppercase correctly") {
-        auto upper1 = "FOOBAR";
-        auto upper2 = static_cast<char*>(SMemAlloc(SStrLen(upper1) + 1, __FILE__, __LINE__, 0x0));
-        SStrCopy(upper2, upper1, STORM_MAX_STR);
-        SStrUpper(upper2);
-        auto compare = SStrCmp(upper2, "FOOBAR", SStrLen(upper2));
-        SMemFree(upper2);
+        char string[] = "FOOBAR";
+        SStrUpper(string);
 
-        REQUIRE(!compare);
+        REQUIRE(!SStrCmp(string, "FOOBAR"));
+    }
+
+    SECTION("does nothing on empty string") {
+        char string[] = "";
+        SStrUpper(string);
+
+        REQUIRE(!SStrCmp(string, ""));
     }
 }

--- a/test/String.cpp
+++ b/test/String.cpp
@@ -44,7 +44,7 @@ TEST_CASE("SStrChr const", "[string]") {
 }
 
 TEST_CASE("SStrChr", "[string]") {
-    char* string = "foobar";
+    char string[] = "foobar";
 
     static_assert(std::is_same<decltype(SStrChr(string, 'f')), char*>::value, "Expect result to be char*");
 
@@ -69,7 +69,7 @@ TEST_CASE("SStrChr", "[string]") {
     }
 
     SECTION("returns nullptr when string is empty") {
-        char* string = "";
+        char string[] = "";
         char* result = SStrChr(string, 'z');
         REQUIRE(result == nullptr);
     }
@@ -123,7 +123,7 @@ TEST_CASE("SStrChrR const", "[string]") {
 }
 
 TEST_CASE("SStrChrR", "[string]") {
-    char* string = "ffoobbaarr";
+    char string[] = "ffoobbaarr";
 
     static_assert(std::is_same<decltype(SStrChrR(string, 'f')), char*>::value, "Expect result to be char*");
 
@@ -143,7 +143,7 @@ TEST_CASE("SStrChrR", "[string]") {
     }
 
     SECTION("finds last character when it exists at start and end of string") {
-        char* string = "ffoobbaarrff";
+        char string[] = "ffoobbaarrff";
         char* result = SStrChrR(string, 'f');
         REQUIRE(result == string + 11);
     }
@@ -154,7 +154,7 @@ TEST_CASE("SStrChrR", "[string]") {
     }
 
     SECTION("returns nullptr when string is empty") {
-        char* string = "";
+        char string[] = "";
         char* result = SStrChrR(string, 'z');
         REQUIRE(result == nullptr);
     }
@@ -537,7 +537,7 @@ TEST_CASE("SStrVPrintf", "[string]") {
 }
 
 TEST_CASE("SStrStr", "[string]") {
-    char* string = "foobar";
+    char string[] = "foobar";
 
     static_assert(std::is_same<decltype(SStrStr(string, "")), char*>::value, "Expect result to be char*");
 
@@ -567,7 +567,7 @@ TEST_CASE("SStrStr", "[string]") {
     }
 
     SECTION("returns nullptr when given empty string") {
-        char* string = "";
+        char string[] = "";
         char* substring = SStrStr(string, "bar");
         REQUIRE(substring == nullptr);
     }
@@ -610,7 +610,7 @@ TEST_CASE("SStrStr const", "[string]") {
 }
 
 TEST_CASE("SStrStrI", "[string]") {
-    char* string = "foobar";
+    char string[] = "foobar";
 
     static_assert(std::is_same<decltype(SStrStrI(string, "")), char*>::value, "Expect result to be char*");
 
@@ -640,7 +640,7 @@ TEST_CASE("SStrStrI", "[string]") {
     }
 
     SECTION("returns nullptr when given empty string") {
-        char* string = "";
+        char string[] = "";
         char* substring = SStrStrI(string, "bar");
         REQUIRE(substring == nullptr);
     }


### PR DESCRIPTION
This PR improves test coverage for string functions and adds the following:

| Ordinal | Name |
|----|----|
|502|SStrHash|
|573|SStrToDouble|
|576|SStrToUnsigned|
|581|SStrVPrintf|
|584|SStrStr (non-const)|
|586|SStrStrI (non-const)|
|587|SStrStrI (const)|
