### PR TITLE
chore(region): make implementation of SRgnDuplicate conditional

### DIFF
--- a/storm/Region.cpp
+++ b/storm/Region.cpp
@@ -460,6 +460,7 @@ void SRgnDelete(HSRGN handle) {
 }
 
 void SRgnDuplicate(HSRGN origHandle, HSRGN* handle, uint32_t reserved) {
+#if defined(WHOA_STORM_C_CRIT_SECT_RECURSIVE)
     STORM_VALIDATE_BEGIN;
     STORM_VALIDATE(handle);
     *handle = nullptr;
@@ -475,18 +476,16 @@ void SRgnDuplicate(HSRGN origHandle, HSRGN* handle, uint32_t reserved) {
         return;
     }
 
-#if defined(WHOA_STORM_C_CRIT_SECT_RECURSIVE)
     HLOCKEDRGN newlockedhandle;
 
     auto newrgn = s_rgntable.NewLock(handle, &newlockedhandle);
     *newrgn = *rgn;
-    s_rgntable.Unlock(newlockedhandle);
-#else
-    auto newrgn = s_rgntable.New(handle);
-    *newrgn = *rgn;
-#endif
 
+    s_rgntable.Unlock(newlockedhandle);
     s_rgntable.Unlock(origlockedhandle);
+#else
+    STORM_ASSERT_FATAL(!"SRgnDuplicate is not implemented in this build");
+#endif
 }
 
 void SRgnGetBoundingRectf(HSRGN handle, RECTF* rect) {

--- a/test/Region.cpp
+++ b/test/Region.cpp
@@ -451,6 +451,7 @@ TEST_CASE("SRgnDelete", "[region]") {
     }
 }
 
+#if defined(WHOA_STORM_C_CRIT_SECT_RECURSIVE)
 TEST_CASE("SRgnDuplicate", "[region]") {
     RgnDataTest region;
     RECTF baseRect = { -1.0f, 1.0f, 1.0f, 2.0f };
@@ -503,6 +504,7 @@ TEST_CASE("SRgnDuplicate", "[region]") {
         CHECK(newrgn == nullptr);
     }
 }
+#endif
 
 TEST_CASE("SRgnGetBoundingRectf", "[region]") {
     RgnDataTest region;


### PR DESCRIPTION
Make the entire implementation of `SRgnDuplicate` conditional when the recursive `CCritSect` define is absent. I think we'll prefer this over an alternative implementation that doesn't quite match the original's semantics.

In the unimplemented scenario, the function remains defined but asserts with an unimplemented message if invoked.