### PR TITLE
fix(queue): add missing initializers to CSBasePriority

### DIFF
--- a/storm/queue/CSBasePriority.hpp
+++ b/storm/queue/CSBasePriority.hpp
@@ -8,8 +8,8 @@ class CSBasePriorityQueue;
 class CSBasePriority {
     public:
     // Member variables
-    CSBasePriorityQueue* m_queue;
-    uint32_t m_index;
+    CSBasePriorityQueue* m_queue = nullptr;
+    uint32_t m_index = 0;
 
     // Member functions
     virtual bool Compare(CSBasePriority* a) = 0;


### PR DESCRIPTION
Verified against World of Warcraft 0.5.3 and Warcraft III: Reforged 2.0.1.