### PR TITLE
feat(memory): add trivial SMem functions

### DIFF
--- a/storm/Memory.cpp
+++ b/storm/Memory.cpp
@@ -1,5 +1,7 @@
 #include "storm/Memory.hpp"
 
+#include <cstring>
+
 constexpr size_t ALIGNMENT = 8;
 
 void* SMemAlloc(size_t bytes, const char* filename, int32_t linenumber, uint32_t flags) {
@@ -19,6 +21,10 @@ void* SMemAlloc(size_t bytes, const char* filename, int32_t linenumber, uint32_t
         // TODO handle errors
         return nullptr;
     }
+}
+
+void SMemFill(void* ptr, size_t bytes, uint8_t value) {
+    memset(ptr, value, bytes);
 }
 
 void SMemFree(void* ptr) {

--- a/storm/Memory.cpp
+++ b/storm/Memory.cpp
@@ -2,7 +2,9 @@
 
 #include <cstring>
 
+
 constexpr size_t ALIGNMENT = 8;
+
 
 void* SMemAlloc(size_t bytes, const char* filename, int32_t linenumber, uint32_t flags) {
     size_t alignedBytes = (bytes + (ALIGNMENT - 1)) & ~(ALIGNMENT - 1);
@@ -23,6 +25,10 @@ void* SMemAlloc(size_t bytes, const char* filename, int32_t linenumber, uint32_t
     }
 }
 
+void SMemCopy(void* dst, void* src, size_t bytes) {
+    memmove(dst, src, bytes);
+}
+
 void SMemFill(void* ptr, size_t bytes, uint8_t value) {
     memset(ptr, value, bytes);
 }
@@ -37,6 +43,10 @@ void SMemFree(void* ptr, const char* filename, int32_t linenumber, uint32_t flag
     if (ptr) {
         free(ptr);
     }
+}
+
+void SMemMove(void* dst, void* src, size_t bytes) {
+    memmove(dst, src, bytes);
 }
 
 void* SMemReAlloc(void* ptr, size_t bytes, const char* filename, int32_t linenumber, uint32_t flags) {

--- a/storm/Memory.cpp
+++ b/storm/Memory.cpp
@@ -7,7 +7,7 @@ void* SMemAlloc(size_t bytes, const char* filename, int32_t linenumber, uint32_t
 
     void* result;
 
-    if (flags & 0x8) {
+    if (flags & SMEM_FLAG_ZEROMEMORY) {
         result = calloc(1, alignedBytes);
     } else {
         result = malloc(alignedBytes);

--- a/storm/Memory.cpp
+++ b/storm/Memory.cpp
@@ -70,3 +70,10 @@ void* SMemReAlloc(void* ptr, size_t bytes, const char* filename, int32_t linenum
         return nullptr;
     }
 }
+
+void SMemZero(void* ptr, size_t bytes) {
+    uint8_t* ptrdata = static_cast<uint8_t*>(ptr);
+    for (size_t i = 0; i < bytes; i++) {
+        ptrdata[i] = 0;
+    }
+}

--- a/storm/Memory.hpp
+++ b/storm/Memory.hpp
@@ -10,11 +10,15 @@
 
 void* SMemAlloc(size_t bytes, const char* filename, int32_t linenumber, uint32_t flags = 0);
 
+void SMemCopy(void* dst, void* src, size_t bytes);
+
 void SMemFill(void* ptr, size_t bytes, uint8_t value);
 
 void SMemFree(void* ptr);
 
 void SMemFree(void* ptr, const char* filename, int32_t linenumber, uint32_t flags = 0);
+
+void SMemMove(void* dst, void* src, size_t bytes);
 
 void* SMemReAlloc(void* ptr, size_t bytes, const char* filename, int32_t linenumber, uint32_t flags = 0);
 

--- a/storm/Memory.hpp
+++ b/storm/Memory.hpp
@@ -18,4 +18,6 @@ void SMemFree(void* ptr, const char* filename, int32_t linenumber, uint32_t flag
 
 void* SMemReAlloc(void* ptr, size_t bytes, const char* filename, int32_t linenumber, uint32_t flags = 0);
 
+void SMemZero(void* ptr, size_t bytes);
+
 #endif

--- a/storm/Memory.hpp
+++ b/storm/Memory.hpp
@@ -10,6 +10,8 @@
 
 void* SMemAlloc(size_t bytes, const char* filename, int32_t linenumber, uint32_t flags = 0);
 
+void SMemFill(void* ptr, size_t bytes, uint8_t value);
+
 void SMemFree(void* ptr);
 
 void SMemFree(void* ptr, const char* filename, int32_t linenumber, uint32_t flags = 0);

--- a/storm/Memory.hpp
+++ b/storm/Memory.hpp
@@ -4,12 +4,16 @@
 #include <cstdint>
 #include <cstdlib>
 
-void* SMemAlloc(size_t bytes, const char* filename, int32_t linenumber, uint32_t flags);
+
+#define SMEM_FLAG_ZEROMEMORY 8
+
+
+void* SMemAlloc(size_t bytes, const char* filename, int32_t linenumber, uint32_t flags = 0);
 
 void SMemFree(void* ptr);
 
-void SMemFree(void* ptr, const char* filename, int32_t linenumber, uint32_t flags);
+void SMemFree(void* ptr, const char* filename, int32_t linenumber, uint32_t flags = 0);
 
-void* SMemReAlloc(void* ptr, size_t bytes, const char* filename, int32_t linenumber, uint32_t flags);
+void* SMemReAlloc(void* ptr, size_t bytes, const char* filename, int32_t linenumber, uint32_t flags = 0);
 
 #endif

--- a/test/Memory.cpp
+++ b/test/Memory.cpp
@@ -30,6 +30,27 @@ TEST_CASE("SMemAlloc", "[memory]") {
     }
 }
 
+TEST_CASE("SMemFill", "[memory]") {
+    std::vector<uint8_t> data = { 1, 255, 128, 42, 69, 99, 13, 37 };
+
+    SECTION("replaces bytes") {
+        std::vector<uint8_t> result1(8, 255);
+        SMemFill(data.data(), 8, 255);
+        CHECK_THAT(data, Catch::Matchers::Equals(result1));
+
+        std::vector<uint8_t> result2 = { 0, 0, 0, 0, 0, 255, 255, 255 };
+        SMemFill(data.data(), 5, 0);
+        CHECK_THAT(data, Catch::Matchers::Equals(result2));
+    }
+
+    SECTION("does nothing if size is 0") {
+        std::vector<uint8_t> changedata = data;
+        SMemFill(changedata.data(), 0, 255);
+
+        CHECK_THAT(changedata, Catch::Matchers::Equals(data));
+    }
+}
+
 TEST_CASE("SMemFree", "[memory]") {
     SECTION("does nothing on nullptr") {
         CHECK_NOTHROW(SMemFree(nullptr));

--- a/test/Memory.cpp
+++ b/test/Memory.cpp
@@ -3,6 +3,7 @@
 
 #include <cstring>
 #include <numeric>
+#include <vector>
 
 
 TEST_CASE("SMemAlloc", "[memory]") {
@@ -27,6 +28,38 @@ TEST_CASE("SMemAlloc", "[memory]") {
         void* ptr = SMemAlloc(0, __FILE__, __LINE__);
         REQUIRE(ptr != nullptr);
         SMemFree(ptr);
+    }
+}
+
+TEST_CASE("SMemCopy", "[memory]") {
+    std::vector<uint8_t> data = { 1, 255, 128, 42, 69, 99, 13, 37 };
+
+    SECTION("copies memory") {
+        std::vector<uint8_t> dest(8);
+        SMemCopy(dest.data(), data.data(), 8);
+
+        CHECK_THAT(dest, Catch::Matchers::Equals(data));
+    }
+
+    SECTION("copies nothing if size is 0") {
+        std::vector<uint8_t> dest(8);
+        SMemCopy(dest.data(), data.data(), 0);
+
+        CHECK(std::accumulate(dest.begin(), dest.end(), 0u) == 0);
+    }
+
+    SECTION("copies overlapping memory right") {
+        std::vector<uint8_t> result = { 1, 255, 1, 255, 128, 42, 13, 37 };
+        SMemCopy(data.data() + 2, data.data(), 4);
+
+        CHECK_THAT(data, Catch::Matchers::Equals(result));
+    }
+
+    SECTION("copies overlapping memory left") {
+        std::vector<uint8_t> result = { 1, 255, 69, 99, 13, 37, 13, 37 };
+        SMemCopy(data.data() + 2, data.data() + 4, 4);
+
+        CHECK_THAT(data, Catch::Matchers::Equals(result));
     }
 }
 
@@ -60,6 +93,38 @@ TEST_CASE("SMemFree", "[memory]") {
 TEST_CASE("SMemFree full args", "[memory]") {
     SECTION("does nothing on nullptr") {
         CHECK_NOTHROW(SMemFree(nullptr, __FILE__, __LINE__));
+    }
+}
+
+TEST_CASE("SMemMove", "[memory]") {
+    std::vector<uint8_t> data = { 1, 255, 128, 42, 69, 99, 13, 37 };
+
+    SECTION("copies memory") {
+        std::vector<uint8_t> dest(8);
+        SMemMove(dest.data(), data.data(), 8);
+
+        CHECK_THAT(dest, Catch::Matchers::Equals(data));
+    }
+
+    SECTION("copies nothing if size is 0") {
+        std::vector<uint8_t> dest(8);
+        SMemMove(dest.data(), data.data(), 0);
+
+        CHECK(std::accumulate(dest.begin(), dest.end(), 0u) == 0);
+    }
+
+    SECTION("copies overlapping memory right") {
+        std::vector<uint8_t> result = { 1, 255, 1, 255, 128, 42, 13, 37 };
+        SMemMove(data.data() + 2, data.data(), 4);
+
+        CHECK_THAT(data, Catch::Matchers::Equals(result));
+    }
+
+    SECTION("copies overlapping memory left") {
+        std::vector<uint8_t> result = { 1, 255, 69, 99, 13, 37, 13, 37 };
+        SMemMove(data.data() + 2, data.data() + 4, 4);
+
+        CHECK_THAT(data, Catch::Matchers::Equals(result));
     }
 }
 

--- a/test/Memory.cpp
+++ b/test/Memory.cpp
@@ -1,10 +1,84 @@
 #include "storm/Memory.hpp"
 #include "test/Test.hpp"
 
+#include <cstring>
+#include <numeric>
+
+
 TEST_CASE("SMemAlloc", "[memory]") {
     SECTION("allocates memory") {
-        void* ptr = SMemAlloc(16, __FILE__, __LINE__, 0x0);
+        void* ptr = SMemAlloc(16, __FILE__, __LINE__);
+        REQUIRE(ptr != nullptr);
+        CHECK_NOTHROW(memset(ptr, 1, 16));
+        SMemFree(ptr);
+    }
+
+    SECTION("allocates memory initialized to 0 with flag") {
+        void* ptr = SMemAlloc(16, __FILE__, __LINE__, SMEM_FLAG_ZEROMEMORY);
+        REQUIRE(ptr != nullptr);
+
+        uint8_t* pArray = static_cast<uint8_t*>(ptr);
+        CHECK(std::accumulate(pArray, pArray + 16, 0u) == 0);
+
+        SMemFree(ptr);
+    }
+
+    SECTION("allocates a memory pointer even if the size is 0") {
+        void* ptr = SMemAlloc(0, __FILE__, __LINE__);
         REQUIRE(ptr != nullptr);
         SMemFree(ptr);
+    }
+}
+
+TEST_CASE("SMemFree", "[memory]") {
+    SECTION("does nothing on nullptr") {
+        CHECK_NOTHROW(SMemFree(nullptr));
+    }
+}
+
+TEST_CASE("SMemFree full args", "[memory]") {
+    SECTION("does nothing on nullptr") {
+        CHECK_NOTHROW(SMemFree(nullptr, __FILE__, __LINE__));
+    }
+}
+
+TEST_CASE("SMemReAlloc", "[memory]") {
+    SECTION("allocates memory") {
+        void* ptr = SMemReAlloc(nullptr, 16, __FILE__, __LINE__);
+        REQUIRE(ptr != nullptr);
+        CHECK_NOTHROW(memset(ptr, 1, 16));
+        SMemFree(ptr);
+    }
+
+    SECTION("allocates memory initialized to 0 with flag") {
+        void* ptr = SMemReAlloc(nullptr, 16, __FILE__, __LINE__, SMEM_FLAG_ZEROMEMORY);
+        REQUIRE(ptr != nullptr);
+
+        uint8_t* pArray = static_cast<uint8_t*>(ptr);
+        CHECK(std::accumulate(pArray, pArray + 16, 0u) == 0);
+
+        SMemFree(ptr);
+    }
+
+    SECTION("allocates a memory pointer even if the size is 0") {
+        void* ptr = SMemReAlloc(nullptr, 0, __FILE__, __LINE__);
+        REQUIRE(ptr != nullptr);
+        SMemFree(ptr);
+    }
+
+    SECTION("reallocates memory") {
+        void* ptr = SMemAlloc(16, __FILE__, __LINE__);
+        REQUIRE(ptr != nullptr);
+
+        *static_cast<uint32_t*>(ptr) = 123456;
+
+        // 1MB
+        void* ptr2 = SMemReAlloc(ptr, 1024 * 1024, __FILE__, __LINE__);
+        REQUIRE(ptr2 != nullptr);
+
+        CHECK(*static_cast<uint32_t*>(ptr2) == 123456);
+        CHECK_NOTHROW(memset(ptr2, 1, 1024 * 1024));
+
+        SMemFree(ptr2);
     }
 }

--- a/test/Memory.cpp
+++ b/test/Memory.cpp
@@ -103,3 +103,21 @@ TEST_CASE("SMemReAlloc", "[memory]") {
         SMemFree(ptr2);
     }
 }
+
+TEST_CASE("SMemZero", "[memory]") {
+    std::vector<uint8_t> data = { 1, 255, 128, 42, 69, 99, 13, 37 };
+
+    SECTION("zeroes out memory") {
+        std::vector<uint8_t> result = { 0, 0, 0, 0, 0, 99, 13, 37 };
+        SMemZero(data.data(), 5);
+
+        CHECK_THAT(data, Catch::Matchers::Equals(result));
+    }
+
+    SECTION("does nothing if size is 0") {
+        std::vector<uint8_t> change = data;
+        SMemZero(change.data(), 0);
+
+        CHECK_THAT(change, Catch::Matchers::Equals(data));
+    }
+}


### PR DESCRIPTION
Adds the following SMem functions from Starcraft-era Storm.

```
491	SMemCopy
492	SMemFill
493	SMemMove
494	SMemZero
```

Adds more tests, default values, and flag for existing functions.
