### PR TITLE
feat(hash): finish implementation of HASHKEY classes

### DIFF
--- a/storm/hash/Hashkey.cpp
+++ b/storm/hash/Hashkey.cpp
@@ -14,8 +14,17 @@ HASHKEY_PTR::HASHKEY_PTR(void* key) {
     this->m_key = key;
 }
 
+HASHKEY_PTR& HASHKEY_PTR::operator=(const HASHKEY_PTR& key) {
+    this->m_key = key.m_key;
+    return *this;
+}
+
 bool HASHKEY_PTR::operator==(const HASHKEY_PTR& key) const {
     return this->m_key == key.m_key;
+}
+
+void* HASHKEY_PTR::GetPtr() const {
+    return this->m_key;
 }
 
 HASHKEY_STR::HASHKEY_STR() {
@@ -28,14 +37,14 @@ HASHKEY_STR::HASHKEY_STR(const char* str) {
 
 HASHKEY_STR::~HASHKEY_STR() {
     if (this->m_str) {
-        SMemFree(this->m_str, __FILE__, __LINE__, 0x0);
+        SMemFree(this->m_str, __FILE__, __LINE__);
     }
 }
 
 HASHKEY_STR& HASHKEY_STR::operator=(const char* str) {
     if (this->m_str != str) {
         if (this->m_str) {
-            SMemFree(this->m_str, __FILE__, __LINE__, 0x0);
+            SMemFree(this->m_str, __FILE__, __LINE__);
         }
 
         this->m_str = SStrDupA(str, __FILE__, __LINE__);
@@ -44,15 +53,40 @@ HASHKEY_STR& HASHKEY_STR::operator=(const char* str) {
     return *this;
 }
 
+HASHKEY_STR& HASHKEY_STR::operator=(const HASHKEY_STR& key) {
+    this->operator=(key.m_str);
+
+    return *this;
+}
+
 bool HASHKEY_STR::operator==(const char* str) const {
-    return SStrCmp(this->m_str, str, STORM_MAX_STR) == 0;
+    return SStrCmp(this->m_str, str) == 0;
+}
+
+bool HASHKEY_STR::operator==(const HASHKEY_STR& key) const {
+    return this->operator==(key.m_str);
+}
+
+const char* HASHKEY_STR::GetString() const {
+    return this->m_str;
 }
 
 HASHKEY_STRI& HASHKEY_STRI::operator=(const char* str) {
     static_cast<HASHKEY_STR&>(*this) = str;
+
+    return *this;
+}
+
+HASHKEY_STRI& HASHKEY_STRI::operator=(const HASHKEY_STRI& key) {
+    static_cast<HASHKEY_STR&>(*this) = key.m_str;
+
     return *this;
 }
 
 bool HASHKEY_STRI::operator==(const char* str) const {
-    return SStrCmpI(this->m_str, str, STORM_MAX_STR) == 0;
+    return SStrCmpI(this->m_str, str) == 0;
+}
+
+bool HASHKEY_STRI::operator==(const HASHKEY_STRI& key) const {
+    return this->operator==(key.m_str);
 }

--- a/storm/hash/Hashkey.hpp
+++ b/storm/hash/Hashkey.hpp
@@ -1,41 +1,52 @@
 #ifndef STORM_HASH_HASHKEY_HPP
 #define STORM_HASH_HASHKEY_HPP
 
+class HASHKEY_NONE {
+    public:
+    // Member functions
+    bool operator==(const HASHKEY_NONE& key);
+};
+
 class HASHKEY_PTR {
     public:
-    // Member variables
-    void* m_key;
-
     // Member functions
     HASHKEY_PTR();
     HASHKEY_PTR(void* key);
+    HASHKEY_PTR& operator=(const HASHKEY_PTR& key);
     bool operator==(const HASHKEY_PTR& key) const;
+    void* GetPtr() const;
+
+    private:
+    // Member variables
+    void* m_key;
 };
 
 class HASHKEY_STR {
     public:
-    // Member variables
-    char* m_str;
-
     // Member functions
     HASHKEY_STR();
     HASHKEY_STR(const char* str);
     ~HASHKEY_STR();
     HASHKEY_STR& operator=(const char* str);
+    HASHKEY_STR& operator=(const HASHKEY_STR& key);
     bool operator==(const char* str) const;
+    bool operator==(const HASHKEY_STR& key) const;
+    const char* GetString() const;
+
+    protected:
+    // Member variables
+    char* m_str;
 };
 
 class HASHKEY_STRI : public HASHKEY_STR {
     public:
     // Member functions
+    HASHKEY_STRI() : HASHKEY_STR() {};
+    HASHKEY_STRI(const char* str) : HASHKEY_STR(str) {};
     HASHKEY_STRI& operator=(const char* str);
+    HASHKEY_STRI& operator=(const HASHKEY_STRI& key);
     bool operator==(const char* str) const;
-};
-
-class HASHKEY_NONE {
-    public:
-    // Member functions
-    bool operator==(const HASHKEY_NONE& key);
+    bool operator==(const HASHKEY_STRI& key) const;
 };
 
 #endif

--- a/test/Hash.cpp
+++ b/test/Hash.cpp
@@ -17,20 +17,118 @@ typedef void* TestExportLockedHandle;
 TEST_CASE("HASHKEY_PTR", "[hash]") {
     SECTION("constructs correctly") {
         HASHKEY_PTR key1;
-        HASHKEY_PTR key2;
-        REQUIRE(key1 == key2);
+        REQUIRE(key1.GetPtr() == nullptr);
 
         void* ptr = reinterpret_cast<void*>(0xDEAFBEEF);
-        HASHKEY_PTR key3 = { ptr };
-        HASHKEY_PTR key4 = { ptr };
-        REQUIRE(key3 == key4);
+        HASHKEY_PTR key2 = { ptr };
+        REQUIRE(key2.GetPtr() == ptr);
+    }
+}
+
+TEST_CASE("HASHKEY_PTR::operator=") {
+    SECTION("assigns from another key") {
+        void* ptr1 = reinterpret_cast<void*>(0xDEAFBEEF);
+        HASHKEY_PTR key1 = { ptr1 };
+        void* ptr2 = reinterpret_cast<void*>(0xFEEDFACE);
+        HASHKEY_PTR key2 = { ptr2 };
+        REQUIRE (!(key1 == key2));
+
+        key1 = key2;
+        REQUIRE(key1 == key2);
+    }
+}
+
+TEST_CASE("HASHKEY_PTR::operator==") {
+    SECTION("compares to another key") {
+        void* ptr1 = reinterpret_cast<void*>(0xDEAFBEEF);
+        HASHKEY_PTR key1 = { ptr1 };
+        HASHKEY_PTR key2 = { ptr1 };
+        REQUIRE(key1 == key2);
+
+        void* ptr2 = reinterpret_cast<void*>(0xFEEDFACE);
+        HASHKEY_PTR key3 = { ptr2 };
+        REQUIRE(!(key1 == key3));
     }
 }
 
 TEST_CASE("HASHKEY_STR", "[hash]") {
     SECTION("constructs correctly") {
+        HASHKEY_STR key1;
+        REQUIRE(key1.GetString() == nullptr);
+
+        HASHKEY_STR key2 = { "foo" };
+        REQUIRE(SStrCmp(key2.GetString(), "foo") == 0);
+    }
+}
+
+TEST_CASE("HASHKEY_STR::operator=") {
+    SECTION("assigns from another string") {
+        HASHKEY_STR key;
+        key = "foo";
+        REQUIRE(SStrCmp(key.GetString(), "foo") == 0);
+    }
+
+    SECTION("assigns from another key") {
+        HASHKEY_STR key1 = { "foo" };
+        HASHKEY_STR key2 = { "bar" };
+        REQUIRE(!(key1 == key2));
+
+        key1 = key2;
+        REQUIRE(key1 == key2);
+    }
+}
+
+TEST_CASE("HASHKEY_STR::operator==") {
+    SECTION("compares to another string") {
         HASHKEY_STR key = { "foo" };
         REQUIRE(key == "foo");
+        REQUIRE(!(key == "FOO"));
+    }
+
+    SECTION("compares to another key") {
+        HASHKEY_STR key1 = { "foo" };
+        HASHKEY_STR key2 = { "foo" };
+        REQUIRE(key1 == key2);
+    }
+}
+
+TEST_CASE("HASHKEY_STRI", "[hash]") {
+    SECTION("constructs correctly") {
+        HASHKEY_STRI key1;
+        REQUIRE(key1.GetString() == nullptr);
+
+        HASHKEY_STRI key2 = { "foo" };
+        REQUIRE(SStrCmp(key2.GetString(), "foo") == 0);
+    }
+}
+
+TEST_CASE("HASHKEY_STRI::operator=") {
+    SECTION("assigns from another string") {
+        HASHKEY_STRI key;
+        key = "foo";
+        REQUIRE(SStrCmp(key.GetString(), "foo") == 0);
+    }
+
+    SECTION("assigns from another key") {
+        HASHKEY_STRI key1 = { "foo" };
+        HASHKEY_STRI key2 = { "bar" };
+        REQUIRE(!(key1 == key2));
+
+        key1 = key2;
+        REQUIRE(key1 == key2);
+    }
+}
+
+TEST_CASE("HASHKEY_STRI::operator==") {
+    SECTION("compares to another string") {
+        HASHKEY_STRI key = { "foo" };
+        REQUIRE(key == "FOO");
+    }
+
+    SECTION("compares to another key") {
+        HASHKEY_STRI key1 = { "foo" };
+        HASHKEY_STRI key2 = { "Foo" };
+        REQUIRE(key1 == key2);
     }
 }
 


### PR DESCRIPTION
This PR corrects member visibility in `HASHKEY_PTR` and `HASHKEY_STR`, and adds the remaining assignment and equality operators to `HASHKEY_PTR`, `HASHKEY_STR`, and `HASHKEY_STRI`.