### PR TITLE
feat(handle): improve handle macros

### DIFF
--- a/storm/Handle.hpp
+++ b/storm/Handle.hpp
@@ -1,10 +1,12 @@
 #ifndef STORM_HANDLE_HPP
 #define STORM_HANDLE_HPP
 
-#if !defined(DECLARE_HANDLE)
-#define DECLARE_HANDLE(name) \
-    struct name##__;         \
+#define DECLARE_STORM_HANDLE(name)          \
+    struct name##__ { int32_t unused; };    \
     typedef struct name##__* name
-#endif
+
+#define DECLARE_STORM_CHILD_HANDLE(name, super)             \
+    struct name##__ : public super##__ { int32_t unused; }; \
+    typedef struct name##__* name
 
 #endif

--- a/storm/region/Types.hpp
+++ b/storm/region/Types.hpp
@@ -4,9 +4,9 @@
 #include "storm/Handle.hpp"
 #include <cstdint>
 
-DECLARE_HANDLE(HSRGN);
+DECLARE_STORM_HANDLE(HSRGN);
 
-DECLARE_HANDLE(HLOCKEDRGN);
+DECLARE_STORM_HANDLE(HLOCKEDRGN);
 
 struct RECTF {
     float left;

--- a/test/Handle.cpp
+++ b/test/Handle.cpp
@@ -1,0 +1,23 @@
+#include "storm/Handle.hpp"
+#include "test/Test.hpp"
+
+TEST_CASE("DECLARE_STORM_HANDLE", "[handle]") {
+    SECTION("declares handle") {
+        DECLARE_STORM_HANDLE(HTEST);
+        HTEST test;
+
+        SUCCEED();
+    }
+}
+
+TEST_CASE("DECLARE_STORM_CHILD_HANDLE", "[handle]") {
+    SECTION("declares child handle") {
+        DECLARE_STORM_HANDLE(HPARENT);
+        DECLARE_STORM_CHILD_HANDLE(HCHILD, HPARENT);
+
+        HPARENT parent;
+        HCHILD child;
+
+        SUCCEED();
+    }
+}


### PR DESCRIPTION
- Rename `DECLARE_HANDLE` to prevent conflicts with the Win32 macro of the same name
- Add `DECLARE_STORM_CHILD_HANDLE` to permit subclassing handles
- Add `int32_t unused` member to handle structs to match Win32's strict handle flavor (which how all handle types in Storm work)