### PR TITLE
feat(memory): replace global new and delete operators

### DIFF
--- a/storm/Memory.cpp
+++ b/storm/Memory.cpp
@@ -4,6 +4,26 @@
 
 constexpr size_t ALIGNMENT = 8;
 
+void* operator new(size_t bytes) {
+    return SMemAlloc(bytes, "new", -1, 0x0);
+}
+
+void* operator new[](size_t bytes) {
+    return SMemAlloc(bytes, "new[]", -1, 0x0);
+}
+
+void operator delete(void* ptr) noexcept {
+    if (ptr) {
+        SMemFree(ptr, "delete", -1, 0x0);
+    }
+}
+
+void operator delete[](void* ptr) noexcept {
+    if (ptr) {
+        SMemFree(ptr, "delete[]", -1, 0x0);
+    }
+}
+
 void* SMemAlloc(size_t bytes, const char* filename, int32_t linenumber, uint32_t flags) {
     size_t alignedBytes = (bytes + (ALIGNMENT - 1)) & ~(ALIGNMENT - 1);
 

--- a/test/Memory.cpp
+++ b/test/Memory.cpp
@@ -5,6 +5,24 @@
 #include <numeric>
 #include <vector>
 
+TEST_CASE("operator new", "[memory]") {
+    SECTION("allocates memory") {
+        auto ptr = new int32_t;
+        REQUIRE(ptr != nullptr);
+
+        delete ptr;
+    }
+}
+
+TEST_CASE("operator new[]", "[memory]") {
+    SECTION("allocates memory") {
+        auto ptr = new int32_t[10];
+        REQUIRE(ptr != nullptr);
+
+        delete[] ptr;
+    }
+}
+
 TEST_CASE("SMemAlloc", "[memory]") {
     SECTION("allocates memory") {
         void* ptr = SMemAlloc(16, __FILE__, __LINE__);


### PR DESCRIPTION
This PR replaces the global memory allocation operators `new`, `new[]`, `delete` and `delete[]` with implementations that call `SMemAlloc` and `SMemFree`, matching client behavior.