### PR TITLE
fix(event): fix SEvtPushState incorrectly cloning the state

### DIFF
--- a/storm/Event.cpp
+++ b/storm/Event.cpp
@@ -95,6 +95,7 @@ void CopyIdHashTable(_IDHASHTABLE *dest, _IDHASHTABLE *source) {
 
             *ppDestData = pNewEntry;
             *pNewEntry = *pSourceData;
+            ppDestData = &(*ppDestData)->next;
         }
         *ppDestData = nullptr;
     }

--- a/test/Event.cpp
+++ b/test/Event.cpp
@@ -312,6 +312,9 @@ TEST_CASE("SEvtPopState", "[event]") {
         SEvtRegisterHandler(1337, 420, 69, 0, &TestEventHandler1);
         CHECK(SEvtPushState(1337, 420) == 1);
 
+        // State is duplicated, remove our duplicated handler
+        SEvtUnregisterHandler(1337, 420, 69, &TestEventHandler1);
+
         CHECK(SEvtDispatch(1337, 420, 69, nullptr) == 0);
         CHECK(test.NumCalls() == 0);
 
@@ -325,7 +328,9 @@ TEST_CASE("SEvtPopState", "[event]") {
         SEvtRegisterHandler(1337, 420, 69, 0, &TestEventHandler1);
         CHECK(SEvtPushState(1337, 420) == 1);
 
-        CHECK(SEvtUnregisterHandler(1337, 420, 69, &TestEventHandler1) == 0);
+        // Unregisters the duplicated instance
+        CHECK(SEvtUnregisterHandler(1337, 420, 69, &TestEventHandler1) == 1);
+
         CHECK(SEvtPopState(1337, 420) == 0);
         CHECK(SEvtUnregisterHandler(1337, 420, 69, &TestEventHandler1) == 1);
     }
@@ -351,12 +356,12 @@ TEST_CASE("SEvtPushState", "[event]") {
         CHECK(SEvtPushState(0, 0) == 1);
     }
 
-    SECTION("pushed state won't receive callbacks") {
+    SECTION("pushed state duplicates its callbacks") {
         SEvtRegisterHandler(1337, 420, 69, 0, &TestEventHandler1);
         CHECK(SEvtPushState(1337, 420) == 1);
 
-        CHECK(SEvtDispatch(1337, 420, 69, nullptr) == 0);
-        CHECK(test.NumCalls() == 0);
+        CHECK(SEvtDispatch(1337, 420, 69, nullptr) == 1);
+        CHECK(test.NumCalls() == 1);
     }
 
     SECTION("pushed state applies to all ids") {
@@ -366,18 +371,18 @@ TEST_CASE("SEvtPushState", "[event]") {
 
         CHECK(SEvtPushState(0, 0) == 1);
 
-        CHECK(SEvtDispatch(0, 0, 9, nullptr) == 0);
-        CHECK(SEvtDispatch(0, 0, 8, nullptr) == 0);
-        CHECK(SEvtDispatch(0, 0, 66, nullptr) == 0);
-        CHECK(test.NumCalls() == 0);
+        CHECK(SEvtDispatch(0, 0, 9, nullptr) == 1);
+        CHECK(SEvtDispatch(0, 0, 8, nullptr) == 1);
+        CHECK(SEvtDispatch(0, 0, 66, nullptr) == 1);
+        CHECK(test.NumCalls() == 3);
     }
 
-    SECTION("pushed state can't be unregistered") {
+    SECTION("pushed state can be unregistered") {
         SEvtRegisterHandler(0, 0, 0, 0, &TestEventHandler1);
         SEvtRegisterHandler(0, 0, 0, 0, &TestEventHandler2);
 
         CHECK(SEvtPushState(0, 0) == 1);
-        CHECK(SEvtUnregisterHandler(0, 0, 0, &TestEventHandler1) == 0);
+        CHECK(SEvtUnregisterHandler(0, 0, 0, &TestEventHandler1) == 1);
     }
 }
 


### PR DESCRIPTION
Caught during DLL testing. Confirmed I missed this in both WoW and other Storm decompiles.